### PR TITLE
Use a higher level ItemManager.CopyItem() instead of ItemManager.Provider

### DIFF
--- a/Source/Sitecore.FakeDb/Data/Engines/DataCommands/CopyItemCommand.cs
+++ b/Source/Sitecore.FakeDb/Data/Engines/DataCommands/CopyItemCommand.cs
@@ -52,7 +52,7 @@
       {
         foreach (Item child in this.Source.Children)
         {
-          ItemManager.Provider.CopyItem(child, copy, this.Deep, child.Name, ID.NewID);
+          ItemManager.CopyItem(child, copy, this.Deep, child.Name, ID.NewID);
         }
       }
 


### PR DESCRIPTION
Sitecore 8 changed the signature of ItemManager.Provider property and it causes a runtime exception if compiled against earlier versions of Sitecore.

I verified that it fixes the issue I had with my tests in 8.
