### PR TITLE
Added support for shortened paths in serialized data

### DIFF
--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/442761B5/link
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/442761B5/link
@@ -1,0 +1,1 @@
+master\sitecore\content\this\path must be very deep\so that it will be shortened\on the filesystem\abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/442761B5/still deeper.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/442761B5/still deeper.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {9897418C-9D6A-4AC9-B08A-15064C9582A9}
+database: master
+path: /sitecore/content/this/path must be very deep/so that it will be shortened/on the filesystem/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz/still deeper
+parent: {D996532F-9865-46F0-BCB7-B854290D781A}
+name: still deeper
+master: {00000000-0000-0000-0000-000000000000}
+template: {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+templatekey: Folder
+
+----version----
+language: en
+version: 1
+revision: 842f7ac8-aa2b-4d25-92b5-cde26857dd25
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150212T200058Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+842f7ac8-aa2b-4d25-92b5-cde26857dd25
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150212T200058:635593680588039037Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/B2381F05/Some deep section.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/B2381F05/Some deep section.item
@@ -1,0 +1,58 @@
+----item----
+version: 1
+id: {0D5DD3F4-B162-4AD2-A9DC-75422C96B996}
+database: master
+path: /sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly/Some deep template/Some deep section
+parent: {4F3157BD-A026-4B97-AF42-F5EE5675BA31}
+name: Some deep section
+master: {00000000-0000-0000-0000-000000000000}
+template: {E269FBB5-3750-427A-9149-7AA950B49301}
+templatekey: Template section
+
+----field----
+field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
+name: __Sortorder
+key: __sortorder
+content-length: 3
+
+200
+----version----
+language: en
+version: 1
+revision: 9fab00de-35f4-4c6f-980f-080498fd9278
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150214T112714Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+9fab00de-35f4-4c6f-980f-080498fd9278
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150214T112714:635595100346671813Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/B2381F05/link
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/B2381F05/link
@@ -1,0 +1,1 @@
+master\sitecore\templates\Sample\much deeper path needed\for testing deserialization of\fields from shortened paths\correctly\Some deep template

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/B9232C39/Some deep field.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/B9232C39/Some deep field.item
@@ -1,0 +1,58 @@
+----item----
+version: 1
+id: {90DE36F0-7239-497D-AB36-5587DF34F669}
+database: master
+path: /sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly/Some deep template/Some deep section/Some deep field
+parent: {0D5DD3F4-B162-4AD2-A9DC-75422C96B996}
+name: Some deep field
+master: {00000000-0000-0000-0000-000000000000}
+template: {455A3E98-A627-4B40-8035-E683A0331AC7}
+templatekey: Template field
+
+----field----
+field: {AB162CC0-DC80-4ABF-8871-998EE5D7BA32}
+name: Type
+key: type
+content-length: 16
+
+Single-Line Text
+----field----
+field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
+name: __Sortorder
+key: __sortorder
+content-length: 3
+
+100
+----version----
+language: en
+version: 1
+revision: c4ace4eb-ecc7-4472-9bec-abb5c206fd76
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150214T112714Z
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+c4ace4eb-ecc7-4472-9bec-abb5c206fd76
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150214T112714:635595100347652512Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/B9232C39/link
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/B9232C39/link
@@ -1,0 +1,1 @@
+master\sitecore\templates\Sample\much deeper path needed\for testing deserialization of\fields from shortened paths\correctly\Some deep template\Some deep section

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/F7A17097/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/F7A17097/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {D996532F-9865-46F0-BCB7-B854290D781A}
+database: master
+path: /sitecore/content/this/path must be very deep/so that it will be shortened/on the filesystem/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+parent: {22A8B1F4-A5F6-46EC-A9B4-51E9618785A8}
+name: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+master: {00000000-0000-0000-0000-000000000000}
+template: {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+templatekey: Folder
+
+----version----
+language: en
+version: 1
+revision: 10430acf-914f-4b2d-ad05-8ef36198b114
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150212T194739Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+10430acf-914f-4b2d-ad05-8ef36198b114
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150212T195145:635593675053781488Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/F7A17097/link
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/F7A17097/link
@@ -1,0 +1,1 @@
+master\sitecore\content\this\path must be very deep\so that it will be shortened\on the filesystem

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/content/this.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/content/this.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {6B0CD7B6-0B82-4E32-877A-5B4D1BBE4AC5}
+database: master
+path: /sitecore/content/this
+parent: {0DE95AE4-41AB-4D01-9EB0-67441B7C2450}
+name: this
+master: {00000000-0000-0000-0000-000000000000}
+template: {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+templatekey: Folder
+
+----version----
+language: en
+version: 1
+revision: cab2afb8-eed6-415c-a607-bbf2cdd6b228
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150212T194522Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+cab2afb8-eed6-415c-a607-bbf2cdd6b228
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150212T194522:635593671226399405Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/content/this/path must be very deep.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/content/this/path must be very deep.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {0977AF6D-A951-46B2-8B1B-4F66E46AB08C}
+database: master
+path: /sitecore/content/this/path must be very deep
+parent: {6B0CD7B6-0B82-4E32-877A-5B4D1BBE4AC5}
+name: path must be very deep
+master: {00000000-0000-0000-0000-000000000000}
+template: {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+templatekey: Folder
+
+----version----
+language: en
+version: 1
+revision: a68b1260-fac7-43d7-8337-19fbf8824cbf
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150212T194528Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+a68b1260-fac7-43d7-8337-19fbf8824cbf
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150212T194952:635593673923077603Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/content/this/path must be very deep/so that it will be shortened.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/content/this/path must be very deep/so that it will be shortened.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {D22C06F2-92D0-459B-AA8D-942389CECD24}
+database: master
+path: /sitecore/content/this/path must be very deep/so that it will be shortened
+parent: {0977AF6D-A951-46B2-8B1B-4F66E46AB08C}
+name: so that it will be shortened
+master: {00000000-0000-0000-0000-000000000000}
+template: {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+templatekey: Folder
+
+----version----
+language: en
+version: 1
+revision: 448d8568-8cfc-4ef7-9707-75c4536710d1
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150212T194547Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+448d8568-8cfc-4ef7-9707-75c4536710d1
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150212T195100:635593674609065314Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/content/this/path must be very deep/so that it will be shortened/on the filesystem.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/content/this/path must be very deep/so that it will be shortened/on the filesystem.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {22A8B1F4-A5F6-46EC-A9B4-51E9618785A8}
+database: master
+path: /sitecore/content/this/path must be very deep/so that it will be shortened/on the filesystem
+parent: {D22C06F2-92D0-459B-AA8D-942389CECD24}
+name: on the filesystem
+master: {00000000-0000-0000-0000-000000000000}
+template: {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+templatekey: Folder
+
+----version----
+language: en
+version: 1
+revision: 71e5f793-5e2e-4d38-917d-9e7905bfcc8f
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150212T194610Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+71e5f793-5e2e-4d38-917d-9e7905bfcc8f
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150212T195138:635593674982240621Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {31397945-C0AE-455D-BF6D-013F3FF74EE8}
+database: master
+path: /sitecore/templates/Sample/much deeper path needed
+parent: {73BAECEB-744D-4D4A-A7A5-7A935638643F}
+name: much deeper path needed
+master: {00000000-0000-0000-0000-000000000000}
+template: {0437FEE2-44C9-46A6-ABE9-28858D9FEE8C}
+templatekey: Template Folder
+
+----version----
+language: en
+version: 1
+revision: 0a3504eb-8a25-47fe-bfff-5459f139c629
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150214T112600Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+0a3504eb-8a25-47fe-bfff-5459f139c629
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150214T112600:635595099603142959Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed/for testing deserialization of.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed/for testing deserialization of.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {DFFB5A4B-2D5E-4B95-9B8C-BC35D8AA49DF}
+database: master
+path: /sitecore/templates/Sample/much deeper path needed/for testing deserialization of
+parent: {31397945-C0AE-455D-BF6D-013F3FF74EE8}
+name: for testing deserialization of
+master: {00000000-0000-0000-0000-000000000000}
+template: {0437FEE2-44C9-46A6-ABE9-28858D9FEE8C}
+templatekey: Template Folder
+
+----version----
+language: en
+version: 1
+revision: 98df9c79-f3eb-4c80-a472-232049f4a1f9
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150214T112619Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+98df9c79-f3eb-4c80-a472-232049f4a1f9
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150214T112619:635595099798541859Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {C59C3A33-278C-4910-A676-A76B096B24B9}
+database: master
+path: /sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths
+parent: {DFFB5A4B-2D5E-4B95-9B8C-BC35D8AA49DF}
+name: fields from shortened paths
+master: {00000000-0000-0000-0000-000000000000}
+template: {0437FEE2-44C9-46A6-ABE9-28858D9FEE8C}
+templatekey: Template Folder
+
+----version----
+language: en
+version: 1
+revision: b88d372a-3e7d-40b2-8c5f-aac5775d53ce
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150214T112630Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+b88d372a-3e7d-40b2-8c5f-aac5775d53ce
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150214T112630:635595099903857069Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {520203D9-2C52-41E6-A44A-97A84D0FBDE3}
+database: master
+path: /sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly
+parent: {C59C3A33-278C-4910-A676-A76B096B24B9}
+name: correctly
+master: {00000000-0000-0000-0000-000000000000}
+template: {0437FEE2-44C9-46A6-ABE9-28858D9FEE8C}
+templatekey: Template Folder
+
+----version----
+language: en
+version: 1
+revision: 18ee9ddb-0b98-44b9-929a-88b4499d22ff
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150214T112634Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+18ee9ddb-0b98-44b9-929a-88b4499d22ff
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150214T112634:635595099949699532Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly/Some deep template.item
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly/Some deep template.item
@@ -1,0 +1,58 @@
+----item----
+version: 1
+id: {4F3157BD-A026-4B97-AF42-F5EE5675BA31}
+database: master
+path: /sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly/Some deep template
+parent: {520203D9-2C52-41E6-A44A-97A84D0FBDE3}
+name: Some deep template
+master: {00000000-0000-0000-0000-000000000000}
+template: {AB86861A-6030-46C5-B394-E8F99E8B87DB}
+templatekey: Template
+
+----field----
+field: {12C33F3F-86C5-43A5-AEB4-5598CEC45116}
+name: __Base template
+key: __base template
+content-length: 38
+
+{1930BBEB-7805-471A-A3BE-4858AC7CF696}
+----version----
+language: en
+version: 1
+revision: 2fda8313-7b51-49f6-a49c-6797f1dd1aee
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20150214T112649Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+2fda8313-7b51-49f6-a49c-6797f1dd1aee
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20150214T112715:635595100351285079Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/Source/Sitecore.FakeDb.Serialization.Tests/DsDbItemTest.cs
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/DsDbItemTest.cs
@@ -196,5 +196,33 @@ namespace Sitecore.FakeDb.Serialization.Tests
                 baseTemplateItem.ID.ShouldBeEquivalentTo(baseTemplateId);
             }
         }
+
+        [Fact]
+        public void ShouldDeserializeShortenedPath()
+        {
+            DsDbItem item = new DsDbItem("/sitecore/content/this/path must be very deep/so that it will be shortened/on the filesystem/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz/still deeper");
+
+            item.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void ShouldDeserializeShortenedPathOneDirectoryHigher()
+        {
+            DsDbItem item = new DsDbItem("/sitecore/content/this/path must be very deep/so that it will be shortened/on the filesystem/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+
+            item.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void ShouldLookupByIdInShortenedPath()
+        {
+            ID id = ID.Parse("{9897418C-9D6A-4AC9-B08A-15064C9582A9}");
+
+            DsDbItem item = new DsDbItem(id);
+
+            item.Should().NotBeNull();
+            item.Name.Should().BeEquivalentTo("still deeper");
+            item.ID.ShouldBeEquivalentTo(id);
+        }
     }
 }

--- a/Source/Sitecore.FakeDb.Serialization.Tests/DsDbTemplateTest.cs
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/DsDbTemplateTest.cs
@@ -96,5 +96,25 @@ namespace Sitecore.FakeDb.Serialization.Tests
             template.Name.Should().BeEquivalentTo("Sample Item");
             template.TemplateID.ShouldBeEquivalentTo(TemplateIDs.Template);
         }
+
+        [Fact]
+        public void ShouldLoadFieldFromShortenedPath()
+        {
+            DsDbTemplate template = new DsDbTemplate(
+                "/sitecore/templates/Sample/much deeper path needed/for testing deserialization of/fields from shortened paths/correctly/Some deep template");
+
+            using (new Db()
+                {
+                    template
+                })
+            {
+                template.Should().NotBeNull();
+
+                ID someDeepFieldId = ID.Parse("{90DE36F0-7239-497D-AB36-5587DF34F669}");
+                template.Fields.Count(f => f.ID == someDeepFieldId).ShouldBeEquivalentTo(1);
+                template.Fields[someDeepFieldId].Name.Should().BeEquivalentTo("Some deep field");
+                template.Fields[someDeepFieldId].Shared.Should().BeFalse();
+            }
+        }
     }
 }

--- a/Source/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -127,5 +128,11 @@
   </Target>
   <Target Name="AfterBuild">
     <XslTransformation XslInputPath="App.config.transform.xslt" XmlInputPaths="$(SolutionDir)\Sitecore.FakeDb.Tests\App.config" OutputPaths="$(OutDir)\$(TargetFileName).config" />
+  </Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0-rc1-build1030\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
 </Project>

--- a/Source/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/Source/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -6,4 +6,5 @@
   <package id="NSubstitute" version="1.8.0.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0-rc1-build1030" targetFramework="net45" />
 </packages>

--- a/Source/Sitecore.FakeDb.Serialization/Deserializer.cs
+++ b/Source/Sitecore.FakeDb.Serialization/Deserializer.cs
@@ -132,16 +132,18 @@ namespace Sitecore.FakeDb.Serialization
         {
             DirectoryInfo serializationFolder = GetSerializationFolder(serializationFolderName);
 
+            string truePath = ShortenedPathsDictionary.FindTruePath(serializationFolder, path);
+
             FileInfo itemLocation = new FileInfo(
                 string.Format(
                     "{0}.item",
                     Path.Combine(
                         serializationFolder.FullName.Trim(new[] { Path.DirectorySeparatorChar }),
-                        path.Replace('/', Path.DirectorySeparatorChar).Trim(new[] { Path.DirectorySeparatorChar }))));
+                        truePath.Replace('/', Path.DirectorySeparatorChar).Trim(new[] { Path.DirectorySeparatorChar }))));
             
             Assert.IsTrue(itemLocation.Exists,
                 string.Format("Serialized item '{0}' could not be found in the path '{1}'; please check the path and if the item is serialized correctly",
-                path,
+                truePath,
                 itemLocation.FullName));
 
             return itemLocation;

--- a/Source/Sitecore.FakeDb.Serialization/Deserializer.cs
+++ b/Source/Sitecore.FakeDb.Serialization/Deserializer.cs
@@ -37,14 +37,61 @@ namespace Sitecore.FakeDb.Serialization
         }
 
         /// <summary>
-        /// The same as deserializes all .item files within a directory and all deeper directories.
+        /// Deserializes all .item files below the item's children folder and all deeper directories.
+        /// Also traverses shortened paths.
         /// </summary>
-        /// <param name="directory"></param>
+        /// <param name="itemFile"></param>
+        /// <param name="syncItem"></param>
+        /// <param name="serializationFolder"></param>
+        /// <param name="maxDepth"></param>
         /// <returns></returns>
-        internal static List<SyncItem> DeserializeAll(this DirectoryInfo directory)
+        internal static List<SyncItem> DeserializeAll(this FileInfo itemFile, SyncItem syncItem, DirectoryInfo serializationFolder, int maxDepth)
         {
-            Assert.ArgumentNotNull(directory, "directory");
-            return directory.GetFiles("*.item", SearchOption.AllDirectories).Select(i => i.Deserialize()).ToList();
+            if (maxDepth <= 0)
+            {
+                return new List<SyncItem>();
+            }
+            Assert.ArgumentNotNull(itemFile, "itemFile");
+
+            List<SyncItem> result = new List<SyncItem>();
+
+            // Find descendants in direct subfolder
+            if (itemFile.Directory != null)
+            {
+                DirectoryInfo childItemsFolder = new DirectoryInfo(
+                    itemFile.Directory.FullName
+                    + Path.DirectorySeparatorChar
+                    + Path.GetFileNameWithoutExtension(itemFile.Name));
+                if (childItemsFolder.Exists)
+                {
+                    foreach (FileInfo childItemFile
+                        in childItemsFolder.GetFiles("*.item", SearchOption.AllDirectories))
+                    {
+                        SyncItem childSyncItem = childItemFile.Deserialize();
+                        result.AddRange(childItemFile.DeserializeAll(childSyncItem, serializationFolder, maxDepth - 1));
+                        result.Add(childSyncItem);
+                    }
+                }
+            }
+
+            // Find descendants in shortened paths
+            var linkFiles = ShortenedPathsDictionary.GetLocationsFromLinkFiles(serializationFolder);
+            if (linkFiles.ContainsKey(syncItem.ItemPath))
+            {
+                DirectoryInfo truePath = new DirectoryInfo(linkFiles[syncItem.ItemPath]);
+                if (truePath.Exists)
+                {
+                    foreach (FileInfo childItemFile
+                        in truePath.GetFiles("*.item", SearchOption.AllDirectories))
+                    {
+                        SyncItem childSyncItem = childItemFile.Deserialize();
+                        result.AddRange(childItemFile.DeserializeAll(childSyncItem, serializationFolder, maxDepth - 1));
+                        result.Add(childSyncItem);
+                    }
+                }
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -115,6 +162,18 @@ namespace Sitecore.FakeDb.Serialization
 
         /// <summary>
         /// Resolves a sitecore path to the filesystem where it is serialized.
+        /// </summary>
+        /// <param name="path">A valid sitecore item path</param>
+        /// <param name="serializationFolderName">Name of serialization folder as configured in app.config</param>
+        /// <returns></returns>
+        internal static FileInfo ResolveSerializationPath(string path, string serializationFolderName)
+        {
+            DirectoryInfo serializationFolder = GetSerializationFolder(serializationFolderName);
+            return ResolveSerializationPath(path, serializationFolder);
+        }
+
+        /// <summary>
+        /// Resolves a sitecore path to the filesystem where it is serialized.
         /// For example, path=/sitecore/content/item1 and serializationFolderName=master 
         /// Will be resolved to c:\site\data\serialization\master\sitecore\content\item1.item
         /// 
@@ -126,12 +185,10 @@ namespace Sitecore.FakeDb.Serialization
         /// </szfolders>
         /// </summary>
         /// <param name="path">A valid sitecore item path</param>
-        /// <param name="serializationFolderName">Name of serialization folder as configured in app.config</param>
+        /// <param name="serializationFolder">Folder in which serialized items are available</param>
         /// <returns></returns>
-        internal static FileInfo ResolveSerializationPath(string path, string serializationFolderName)
+        internal static FileInfo ResolveSerializationPath(string path, DirectoryInfo serializationFolder)
         {
-            DirectoryInfo serializationFolder = GetSerializationFolder(serializationFolderName);
-
             string truePath = ShortenedPathsDictionary.FindTruePath(serializationFolder, path);
 
             FileInfo itemLocation = new FileInfo(

--- a/Source/Sitecore.FakeDb.Serialization/SerializedIdToPathDictionary.cs
+++ b/Source/Sitecore.FakeDb.Serialization/SerializedIdToPathDictionary.cs
@@ -26,7 +26,19 @@ namespace Sitecore.FakeDb.Serialization
                 else
                 {
                     pathSet = new SerializedIdToPathSet();
-                    pathSet.FilePaths.Push(Deserializer.GetSerializationFolder(serializationFolderName).FullName);
+                    DirectoryInfo serializationFolder
+                        = Deserializer.GetSerializationFolder(serializationFolderName);
+
+                    // Add filepaths for shortened paths
+                    foreach (string shortenedItemsFolder in ShortenedPathsDictionary
+                        .GetLocationsFromLinkFiles(serializationFolder).Values)
+                    {
+                        pathSet.FilePaths.Push(shortenedItemsFolder);
+                    }
+
+                    // Add filepath for root of regular content
+                    pathSet.FilePaths.Push(serializationFolder.FullName);
+                    
                     _pathSets.Add(serializationFolderName, pathSet);
                 }
 
@@ -35,7 +47,6 @@ namespace Sitecore.FakeDb.Serialization
                 {
                     return pathSet.Paths[id];
                 }
-
 
                 while (pathSet.FilePaths.Any())
                 {

--- a/Source/Sitecore.FakeDb.Serialization/ShortenedPathsDictionary.cs
+++ b/Source/Sitecore.FakeDb.Serialization/ShortenedPathsDictionary.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sitecore.FakeDb.Serialization
+{
+    public static class ShortenedPathsDictionary
+    {
+        /// <summary>
+        /// Maps serialization folders to a mapping of shortened paths to their real locations.
+        /// </summary>
+        private static readonly Dictionary<string, Dictionary<string, string>> _shortenedPaths
+            = new Dictionary<string, Dictionary<string, string>>();
+
+        public static string FindTruePath(DirectoryInfo serializationFolder, string path)
+        {
+            lock (_shortenedPaths)
+            {
+                Dictionary<string, string> folderPaths;
+                if (_shortenedPaths.ContainsKey(serializationFolder.FullName))
+                {
+                    folderPaths = _shortenedPaths[serializationFolder.FullName];
+                }
+                else
+                {
+                    folderPaths = new Dictionary<string, string>();
+
+                    // populate the shortened paths for this serialization folder
+                    var locationsFromLinkFiles = GetLocationsFromLinkFiles(serializationFolder);
+
+                    foreach (var fromLinkFile in locationsFromLinkFiles)
+                    {
+                        folderPaths.Add(fromLinkFile.Key, fromLinkFile.Value);
+                    }
+
+                    _shortenedPaths.Add(serializationFolder.FullName, folderPaths);
+                }
+
+                string parentPath = path.TrimEnd(new [] { '/' });
+                parentPath = parentPath.Substring(0, parentPath.LastIndexOf('/'));
+                if (folderPaths.ContainsKey(parentPath))
+                {
+                    return string.Format("/../{0}{1}", Path.GetFileName(folderPaths[parentPath]), path.Substring(parentPath.Length));
+                }
+                return path;
+            }
+        }
+
+        internal static Dictionary<string, string> GetLocationsFromLinkFiles(DirectoryInfo serializationFolder)
+        {
+            var linkFiles = serializationFolder.Parent.GetDirectories()
+                                               .SelectMany(d => d.GetFiles("link"));
+
+            Dictionary<string, string> locationsFromLinkFiles = new Dictionary<string, string>();
+
+            foreach (FileInfo linkFile in linkFiles)
+            {
+                string fullPath = File.ReadAllText(linkFile.FullName);
+                string dbName = fullPath.Substring(0, fullPath.IndexOf('\\'));
+                fullPath = fullPath.Substring(fullPath.IndexOf('\\')).Replace('\\', '/');
+                if (dbName.Equals(serializationFolder.Name, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    locationsFromLinkFiles.Add(fullPath, linkFile.Directory.FullName);
+                }
+            }
+            return locationsFromLinkFiles;
+        }
+    }
+}

--- a/Source/Sitecore.FakeDb.Serialization/Sitecore.FakeDb.Serialization.csproj
+++ b/Source/Sitecore.FakeDb.Serialization/Sitecore.FakeDb.Serialization.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializedIdToPathDictionary.cs" />
     <Compile Include="SerializedIdToPathSet.cs" />
+    <Compile Include="ShortenedPathsDictionary.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sitecore.FakeDb\Sitecore.FakeDb.csproj">


### PR DESCRIPTION
When serialization paths get too long, Sitecore shortens them by placing directories at the root of the serialization tree and placing a "link" file inside, so the path can be resolved when deserializing.

This was not supported by Sitecore.FakeDb.Serialization. I've added support for it now. Including unit testing.