### PR TITLE
Allow reuse of generated templates across all items, not only siblings

### DIFF
--- a/src/Sitecore.FakeDb.Tests/DbTest.cs
+++ b/src/Sitecore.FakeDb.Tests/DbTest.cs
@@ -680,26 +680,36 @@
       }
     }
 
-    [Fact]
-    public void ShouldShareTemplateForSiblinsOnly()
+    [Theory]
+    [InlineData("/sitecore/content/home", "/sitecore/content/site", true)]
+    [InlineData("/sitecore/content/home", "/sitecore/content/site/four", true)]
+    [InlineData("/sitecore/content/home", "/sitecore/content/home/one", false)]
+    [InlineData("/sitecore/content/home/one", "/sitecore/content/site/two", true)]
+    [InlineData("/sitecore/content/site/two", "/sitecore/content/site/three", false)]
+    [InlineData("/sitecore/content/site/two", "/sitecore/content/site/four", false)]
+    public void ShouldReuseGeneratedTemplateFromNotOnlySiblings(string pathOne, string pathTwo, bool match)
     {
-      // arrange & act
+      // arrange
       using (var db = new Db
-                        {
-                          new DbItem("products")
-                            {
-                              new DbItem("hammer")
-                            },
-                          new DbItem("shapes") 
-                        })
       {
-        var productsId = db.GetItem("/sitecore/content/products").TemplateID;
-        var hammerId = db.GetItem("/sitecore/content/products/hammer").TemplateID;
-        var shapesId = db.GetItem("/sitecore/content/shapes").TemplateID;
+        new DbItem("home")
+        {
+          new DbItem("one") {{"Title", "One"}}
+        },
+        new DbItem("site")
+        {
+          new DbItem("two") {{"Title", "Two"}},
+          new DbItem("three") {{"Title", "Three"}, {"Name", "Three"}},
+          new DbItem("four")
+        }
+      })
+      {
+        // act
+        var one = db.GetItem(pathOne);
+        var two = db.GetItem(pathTwo);
 
         // assert
-        productsId.Should().Be(shapesId);
-        productsId.Should().NotBe(hammerId);
+        (one.TemplateID == two.TemplateID).Should().Be(match);
       }
     }
 

--- a/src/Sitecore.FakeDb.Tests/Pipelines/AddDbItem/CreateTemplateTest.cs
+++ b/src/Sitecore.FakeDb.Tests/Pipelines/AddDbItem/CreateTemplateTest.cs
@@ -77,7 +77,7 @@
           new DbItem("outside")
       })
       {
-          // assert
+        // assert
         var home = db.GetItem("/sitecore/content/site/home");
         var outside = db.GetItem("/sitecore/content/outside");
 

--- a/src/Sitecore.FakeDb/Pipelines/AddDbItem/CreateTemplate.cs
+++ b/src/Sitecore.FakeDb/Pipelines/AddDbItem/CreateTemplate.cs
@@ -72,25 +72,16 @@
         return false;
       }
 
-      // find the most recently added sibling with a generated template
+      var fingerprint = string.Concat(item.Fields.Select(f => f.Name));
+
+      // find an item with a generated template that has a matching fields set
       var sourceItem = dataStorage.FakeItems.Values
-        .Where(si => si.ParentID == item.ParentID)
-        .LastOrDefault(si => dataStorage.GetFakeTemplate(si.TemplateID).Generated);
+        .Where(si => si.TemplateID != TemplateIDs.Template)
+        .Where(si => dataStorage.GetFakeTemplate(si.TemplateID) != null)
+        .Where(si => dataStorage.GetFakeTemplate(si.TemplateID).Generated)
+        .FirstOrDefault(si => string.Concat(si.Fields.Select(f => f.Name)) == fingerprint);
 
       if (sourceItem == null)
-      {
-        return false;
-      }
-
-      if (sourceItem.TemplateID == TemplateIDs.Template)
-      {
-        return false;
-      }
-
-      var lastItemTemplateKeys = string.Concat(sourceItem.Fields.Select(f => f.Name));
-      var itemTemplateKeys = string.Concat(item.Fields.Select(f => f.Name));
-
-      if (lastItemTemplateKeys != itemTemplateKeys)
       {
         return false;
       }


### PR DESCRIPTION
There was a test in `DbTest` that was specifically testing that we're only reusing templates from the siblings. I replaced it with a cross-items test that now validates the opposite - that we will reuse a generated (and only generated) template across all fake items as long as fields *fingerprint* matches.