### PR TITLE
Update SerializedIdToPathDictionary.cs

### DIFF
--- a/src/Sitecore.FakeDb.Serialization/SerializedIdToPathDictionary.cs
+++ b/src/Sitecore.FakeDb.Serialization/SerializedIdToPathDictionary.cs
@@ -65,7 +65,14 @@
               }
 
               var itemId = ID.Parse(itemIdStr);
+              
+              if(pathSet.Paths.ContainsKey(itemId))
+              {
+                continue;
+              }
+              
               pathSet.Paths.Add(itemId, file);
+              
               if (itemId == id)
               {
                 foundFile = file;


### PR DESCRIPTION
In case if the TDS serialization contains duplicate items the FakeDB is throwing an exception. It would be nice either to skip this items or provide the meaningful message with the path to the duplicate item.