### PR TITLE
deserialize tree of items with templates

### DIFF
--- a/src/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample.item
+++ b/src/Sitecore.FakeDb.Serialization.Tests/Data/Serialization/master/sitecore/templates/Sample.item
@@ -1,0 +1,234 @@
+----item----
+version: 1
+id: {73BAECEB-744D-4D4A-A7A5-7A935638643F}
+database: master
+path: /sitecore/templates/Sample
+parent: {3C1715FE-6A13-4FCF-845F-DE308BA9741D}
+name: Sample
+master: {00000000-0000-0000-0000-000000000000}
+template: {0437FEE2-44C9-46A6-ABE9-28858D9FEE8C}
+templatekey: Template Folder
+
+----field----
+field: {D85DB4EC-FF89-4F9C-9E7C-A9E0654797FC}
+name: __Editor
+key: __editor
+content-length: 0
+
+
+----field----
+field: {9C6106EA-7A5A-48E2-8CAD-F0F693B1E2D4}
+name: __Read Only
+key: __read only
+content-length: 0
+
+
+----field----
+field: {DEC8D2D5-E3CF-48B6-A653-8E69E2716641}
+name: __Security
+key: __security
+content-length: 0
+
+
+----version----
+language: da
+version: 1
+revision: 665834d9-7625-4832-9a09-c1ea1df7fb2b
+
+----field----
+field: {B5E02AD9-D56F-4C41-A065-A133DB87BDEB}
+name: __Display name
+key: __display name
+content-length: 8
+
+Eksempel
+----field----
+field: {52807595-0F8F-4B20-8D2A-CB71D28C6103}
+name: __Owner
+key: __owner
+content-length: 14
+
+sitecore\admin
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 34
+
+20150408T182518:635641143185798595
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+665834d9-7625-4832-9a09-c1ea1df7fb2b
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 34
+
+20150408T182518:635641143185798595
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin
+----version----
+language: de-DE
+version: 1
+revision: 72a48c96-3f73-4335-be83-15473ad008e3
+
+----field----
+field: {B5E02AD9-D56F-4C41-A065-A133DB87BDEB}
+name: __Display name
+key: __display name
+content-length: 8
+
+Beispiel
+----field----
+field: {52807595-0F8F-4B20-8D2A-CB71D28C6103}
+name: __Owner
+key: __owner
+content-length: 14
+
+sitecore\admin
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 34
+
+20150408T183000:635641146007448576
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+72a48c96-3f73-4335-be83-15473ad008e3
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 34
+
+20150408T183000:635641146007448576
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin
+----version----
+language: en
+version: 1
+revision: fe39dc83-46ec-46ad-a5f7-aabb9b7415eb
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 15
+
+20060531T102844
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\Admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+fe39dc83-46ec-46ad-a5f7-aabb9b7415eb
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 15
+
+20080130T091017
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin
+----version----
+language: ja-JP
+version: 1
+revision: 79062c5e-ed7f-47df-8a55-f38d9b242566
+
+----field----
+field: {B5E02AD9-D56F-4C41-A065-A133DB87BDEB}
+name: __Display name
+key: __display name
+content-length: 4
+
+サンプル
+----field----
+field: {52807595-0F8F-4B20-8D2A-CB71D28C6103}
+name: __Owner
+key: __owner
+content-length: 14
+
+sitecore\admin
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 34
+
+20150408T183450:635641148902323993
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+79062c5e-ed7f-47df-8a55-f38d9b242566
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 34
+
+20150408T183450:635641148902323993
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/src/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeTree.cs
+++ b/src/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeTree.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+
+namespace Sitecore.FakeDb.Serialization.Tests.Deserialize
+{
+  using FluentAssertions;
+  using Xunit;
+
+  [Trait("DeserializeTree", "Deserializing a tree of items")]
+  public class DeserializeTree : IDisposable
+  {
+    protected Db Db { get; private set; }
+
+    public DeserializeTree()
+    {
+      this.Db = new Db
+          {
+              new DsDbItem(SerializationId.SampleTemplateFolder, true)
+                  {
+                      ParentID = TemplateIDs.TemplateFolder
+                  }
+          };
+    }
+
+    [Fact(DisplayName = "Deserializes templates in tree")]
+    public void DeserializesTemplates()
+    {
+        Assert.NotNull(this.Db.Database.GetTemplate(SerializationId.SampleItemTemplate));
+    }
+
+    [Fact(DisplayName = "Deserializes items in tree")]
+    public void DeserializesItems()
+    {
+        var nonTemplateItemCount =
+            this.Db.Database.GetItem(TemplateIDs.TemplateFolder)
+                .Axes.GetDescendants()
+                .Count(x => x.TemplateID != TemplateIDs.Template);
+        Assert.Equal(5, nonTemplateItemCount);
+    }
+
+    public void Dispose()
+    {
+        this.Db.Dispose();
+    }
+  }
+}

--- a/src/Sitecore.FakeDb.Serialization.Tests/SerializationId.cs
+++ b/src/Sitecore.FakeDb.Serialization.Tests/SerializationId.cs
@@ -7,5 +7,7 @@
     public static readonly ID ContentHomeItem = new ID("{110D559F-DEA5-42EA-9C1C-8A5DF7E70EF9}");
 
     public static readonly ID SampleItemTemplate = new ID("{76036F5E-CBCE-46D1-AF0A-4143F9B557AA}");
+
+    public static readonly ID SampleTemplateFolder = new ID("{73BAECEB-744D-4D4A-A7A5-7A935638643F}");
   }
 }

--- a/src/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/src/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="..\Sitecore.FakeDb\Properties\AssemblyVersionInfo.cs">
       <Link>Properties\AssemblyVersionInfo.cs</Link>
     </Compile>
+    <Compile Include="Deserialize\DeserializeTree.cs" />
     <Compile Include="Deserialize\DeserializeExistingTemplate.cs" />
     <Compile Include="Deserialize\DeserializeExistingItem.cs" />
     <Compile Include="Deserialize\DeserializeItemAndAddDuplicate.cs" />

--- a/src/Sitecore.FakeDb.Serialization/DsDbItem.cs
+++ b/src/Sitecore.FakeDb.Serialization/DsDbItem.cs
@@ -44,7 +44,7 @@
     {
     }
 
-    private DsDbItem(string serializationFolderName, SyncItem syncItem, FileInfo file, bool includeDescendants, bool deserializeLinkedTemplate = true)
+    internal DsDbItem(string serializationFolderName, SyncItem syncItem, FileInfo file, bool includeDescendants, bool deserializeLinkedTemplate = true)
       : base(syncItem.Name, ID.Parse(syncItem.ID), ID.Parse(syncItem.TemplateID))
     {
       this.SerializationFolderName = serializationFolderName;

--- a/src/Sitecore.FakeDb.Serialization/DsDbTemplate.cs
+++ b/src/Sitecore.FakeDb.Serialization/DsDbTemplate.cs
@@ -36,12 +36,12 @@
     {
     }
 
-    private DsDbTemplate(FileInfo file, string serializationFolderName)
+    internal DsDbTemplate(FileInfo file, string serializationFolderName)
       : this(serializationFolderName, file.Deserialize(), file)
     {
     }
 
-    private DsDbTemplate(string serializationFolderName, SyncItem syncItem, FileInfo file)
+    internal DsDbTemplate(string serializationFolderName, SyncItem syncItem, FileInfo file)
       : base(syncItem.Name, ID.Parse(syncItem.ID))
     {
       Assert.IsTrue(

--- a/src/Sitecore.FakeDb.Serialization/Pipelines/DeserializeDescendants.cs
+++ b/src/Sitecore.FakeDb.Serialization/Pipelines/DeserializeDescendants.cs
@@ -32,7 +32,14 @@
 
       foreach (var itemFile in childItemsFolder.GetFiles("*.item", SearchOption.TopDirectoryOnly))
       {
-        var childItem = new DsDbItem(dsDbItem.SerializationFolderName, itemFile, true);
+        DbItem childItem;
+        var syncItem = itemFile.Deserialize();
+
+        if (syncItem.TemplateID == TemplateIDs.Template.ToString())
+          childItem = new DsDbTemplate(dsDbItem.SerializationFolderName, syncItem, itemFile);
+        else
+          childItem = new DsDbItem(dsDbItem.SerializationFolderName, syncItem, itemFile, true);
+
         dsDbItem.Children.Add(childItem);
       }
     }

--- a/src/Sitecore.FakeDb.Serialization/Sitecore.FakeDb.Serialization.csproj
+++ b/src/Sitecore.FakeDb.Serialization/Sitecore.FakeDb.Serialization.csproj
@@ -61,11 +61,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sitecore.FakeDb\Sitecore.FakeDb.csproj">
-      <Project>{B1B3C599-9284-4653-9F22-FD0F726984BB}</Project>
+      <Project>{b1b3c599-9284-4653-9f22-fd0f726984bb}</Project>
       <Name>Sitecore.FakeDb</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
I wanted to be able to deserialize all of my project's templates quickly for executing some consistency tests (verify that item templates were included in search index config and referenced templates actually existed and some other stuff like that).

Rather than walk the filesystem or use reflection, like I have seen in some other solutions, it seemed almost trivial to make the DsDbItem constructor be able to handle this. It also preserves the template folder hierarchy.

I added a couple of simple unit tests to prove the functionality.