### PR TITLE
use reflection to allow support for 7 and 8 at the same time

### DIFF
--- a/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
+++ b/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
@@ -269,25 +269,28 @@ namespace Sitecore.FakeDb.Data.Engines
 
       this.FakeItems.Add(TemplateIDs.Folder, new DbTemplate(ItemNames.Folder, TemplateIDs.Folder));
 
-      this.FakeItems.Add(
-        TemplateIDs.StandardTemplate,
-        new DbTemplate(TemplateIDs.StandardTemplate)
-          {
-            new DbField(FieldIDs.BaseTemplate) { Shared = true },
-            new DbField(FieldIDs.Lock) { Shared = true },
-            new DbField(FieldIDs.Security) { Shared = true },
-            new DbField(FieldIDs.Created),
-            new DbField(FieldIDs.CreatedBy),
-            new DbField(FieldIDs.Updated),
-            new DbField(FieldIDs.UpdatedBy),
-            new DbField(FieldIDs.Revision),
-            new DbField(FieldIDs.LayoutField) { Type = "Layout" },
-            new DbField(FieldIDs.FinalLayoutField),
-            new DbField(FieldIDs.DisplayName),
-            new DbField(FieldIDs.Hidden),
-            new DbField(FieldIDs.ReadOnly),
-            new DbField(AnalyticsIds.TrackingField) { Type = "Tracking", Shared = true }
-          });
+      var standardTemplate = new DbTemplate(TemplateIDs.StandardTemplate)
+        {
+          new DbField(FieldIDs.BaseTemplate) {Shared = true},
+          new DbField(FieldIDs.Lock) {Shared = true},
+          new DbField(FieldIDs.Security) {Shared = true},
+          new DbField(FieldIDs.Created),
+          new DbField(FieldIDs.CreatedBy),
+          new DbField(FieldIDs.Updated),
+          new DbField(FieldIDs.UpdatedBy),
+          new DbField(FieldIDs.Revision),
+          new DbField(FieldIDs.LayoutField) {Type = "Layout"},
+          //new DbField(FieldIDs.FinalLayoutField),
+          new DbField(FieldIDs.DisplayName),
+          new DbField(FieldIDs.Hidden),
+          new DbField(FieldIDs.ReadOnly),
+          new DbField(AnalyticsIds.TrackingField) {Type = "Tracking", Shared = true}
+        };
+      var finalLayoutIdField = typeof(FieldIDs).GetField("FinalLayoutField");
+      if (finalLayoutIdField != null)
+        standardTemplate.Add(new DbField((ID)finalLayoutIdField.GetValue(null)));
+
+      this.FakeItems.Add(TemplateIDs.StandardTemplate, standardTemplate);
     }
 
     protected void FillDefaultFakeItems()

--- a/src/Sitecore.FakeDb/FieldNamingHelper.cs
+++ b/src/Sitecore.FakeDb/FieldNamingHelper.cs
@@ -25,9 +25,16 @@
             { FieldIDs.StandardValues, "__Standard values" },
             { FieldIDs.Updated, "__Updated" },
             { FieldIDs.UpdatedBy, "__Updated by" },
-            { FieldIDs.FinalLayoutField, "__Final Renderings" },
+            //{ FieldIDs.FinalLayoutField, "__Final Renderings" },
             { AnalyticsIds.TrackingField, "__Tracking" }
           });
+
+    static FieldNamingHelper()
+    {
+        var finalLayoutIdField = typeof (FieldIDs).GetField("FinalLayoutField");
+        if (finalLayoutIdField != null)
+            WellknownFields.Add((ID)finalLayoutIdField.GetValue(null), "__Final Renderings");
+    }
 
     public KeyValuePair<ID, string> GetFieldIdNamePair(ID id, string name)
     {


### PR DESCRIPTION
After the latest update, I could no longer run FakeDB on any of my Sitecore 7 projects.

The only problem seems to be two places that reference `FieldIDs.FinalLayoutField`.

I added a quick reflection check to discover the field id if it exists, so it will work as expected for Sitecore 8 projects, but will be skipped for older versions. In my tests, this works when compiling FakeDB against either Sitecore 8 dlls or Sitecore 7 dlls.