### PR TITLE
Add support for template field's Source field

### DIFF
--- a/src/Sitecore.FakeDb.Tests/Data/DataProviders/FakeDataProviderTest.cs
+++ b/src/Sitecore.FakeDb.Tests/Data/DataProviders/FakeDataProviderTest.cs
@@ -136,6 +136,18 @@
       result.GetField("Title").IsShared.Should().BeTrue();
     }
 
+    [Theory, AutoData]
+    public void ShouldGetTemplateFieldSource(DbTemplate template)
+    {
+      this.dataProvider.DataStorage.GetFakeTemplates().Returns(new[] { template });
+      template.Fields.Add(new DbField("Multilist") { Source = "/sitecore/content" });
+
+      var result = this.dataProvider.GetTemplates(null).First();
+
+      result.GetField("Multilist").Source.Should().Be("/sitecore/content");
+    }
+
+
     [Theory, DefaultAutoData]
     public void ShouldGetDefaultLanguage(CallContext context)
     {

--- a/src/Sitecore.FakeDb.Tests/DbFieldTest.cs
+++ b/src/Sitecore.FakeDb.Tests/DbFieldTest.cs
@@ -35,6 +35,16 @@
     }
 
     [Fact]
+    public void ShouldSetSource()
+    {
+      // arrange
+      this.field.Source = "/sitecore/content";
+
+      // act & assert
+      this.field.Source.Should().Be("/sitecore/content");
+    }
+
+    [Fact]
     public void ShouldInstantiateVersionsAsSortedDictionary()
     {
       // act

--- a/src/Sitecore.FakeDb.Tests/TemplateTreeBuilderTest.cs
+++ b/src/Sitecore.FakeDb.Tests/TemplateTreeBuilderTest.cs
@@ -66,5 +66,18 @@
       var fieldItem = section.Children.Single();
       fieldItem.Fields[TemplateFieldIDs.Type].Value.Should().Be("General Link");
     }
+
+    [Theory, DefaultAutoData]
+    public void ShouldSaveFieldSource(TemplateTreeBuilder sut, DbTemplate template, DbField field)
+    {
+      field.Source = "/sitecore/content";
+      template.Add(field);
+
+      sut.Build(template);
+
+      var section = template.Children.Single();
+      var fieldItem = section.Children.Single();
+      fieldItem.Fields[TemplateFieldIDs.Source].Value.Should().Be("/sitecore/content");
+    }
   }
 }

--- a/src/Sitecore.FakeDb/Data/DataProviders/FakeDataProvider.cs
+++ b/src/Sitecore.FakeDb/Data/DataProviders/FakeDataProvider.cs
@@ -160,6 +160,7 @@
         var newField = section.AddField(field.Name, field.ID);
         newField.SetShared(field.Shared);
         newField.SetType(field.Type);
+        newField.SetSource(field.Source);
       }
 
       if (ft.ID != TemplateIDs.StandardTemplate)

--- a/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
+++ b/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
@@ -307,7 +307,8 @@ namespace Sitecore.FakeDb.Data.Engines
             Fields =
               {
                 new DbField(TemplateFieldIDs.Type),
-                new DbField(TemplateFieldIDs.Shared)
+                new DbField(TemplateFieldIDs.Shared),
+                new DbField(TemplateFieldIDs.Source)
               }
           });
     }

--- a/src/Sitecore.FakeDb/DbField.cs
+++ b/src/Sitecore.FakeDb/DbField.cs
@@ -52,6 +52,8 @@
 
     public string Type { get; set; }
 
+    public string Source { get; set; }
+
     public string Value
     {
       get { return this.GetValue(Language.Current.Name, Sitecore.Data.Version.Latest.Number); }

--- a/src/Sitecore.FakeDb/Pipelines/AddDbItem/CreateTemplate.cs
+++ b/src/Sitecore.FakeDb/Pipelines/AddDbItem/CreateTemplate.cs
@@ -39,7 +39,8 @@
         var templatefield = new DbField(itemField.Name, itemField.ID)
                               {
                                 Shared = itemField.Shared,
-                                Type = itemField.Type
+                                Type = itemField.Type,
+                                Source = itemField.Source
                               };
         template.Add(templatefield);
       }

--- a/src/Sitecore.FakeDb/TemplateTreeBuilder.cs
+++ b/src/Sitecore.FakeDb/TemplateTreeBuilder.cs
@@ -21,7 +21,8 @@
           new DbItem(field.Name, field.ID, TemplateIDs.TemplateField)
             {
               new DbField(TemplateFieldIDs.Type) { Value = field.Type },
-              new DbField(TemplateFieldIDs.Shared) { Value = field.Shared ? "1" : string.Empty }
+              new DbField(TemplateFieldIDs.Shared) { Value = field.Shared ? "1" : string.Empty },
+              new DbField(TemplateFieldIDs.Source) { Value = field.Source }
             });
       }
     }


### PR DESCRIPTION
This one is needed to test `getLookupSourceItem` pipeline processors, for example