### PR TITLE
Fix #105 by supporting new FieldIDs.SourceItem

### DIFF
--- a/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
+++ b/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
@@ -294,6 +294,7 @@ namespace Sitecore.FakeDb.Data.Engines
             new DbField(FieldIDs.Hidden),
             new DbField(FieldIDs.ReadOnly),
             new DbField(FieldIDs.Source),
+            new DbField(DbFieldIds.SourceItem),
             new DbField(DbFieldIds.AnalyticsIds.PageLevelTestDefinitionField) { Shared = true },
             new DbField(DbFieldIds.AnalyticsIds.TrackingField) { Type = "Tracking", Shared = true },
             new DbField(FieldIDs.DefaultWorkflow) { Shared = true },

--- a/src/Sitecore.FakeDb/DbFieldIds.cs
+++ b/src/Sitecore.FakeDb/DbFieldIds.cs
@@ -5,6 +5,7 @@
   internal static class DbFieldIds
   {
     public static readonly ID FinalLayoutField = new ID("{04BF00DB-F5FB-41F7-8AB7-22408372A981}");
+    public static readonly ID SourceItem = new ID("{19B597D3-2EDD-4AE2-AEFE-4A94C7F10E31}");
 
     internal static class AnalyticsIds
     {

--- a/src/Sitecore.FakeDb/FieldNamingHelper.cs
+++ b/src/Sitecore.FakeDb/FieldNamingHelper.cs
@@ -25,6 +25,7 @@
             { FieldIDs.Updated, "__Updated" },
             { FieldIDs.UpdatedBy, "__Updated by" },
             { FieldIDs.Source, "__Source" },
+            { DbFieldIds.SourceItem, "__Source Item" },
             { DbFieldIds.FinalLayoutField, "__Final Renderings" },
             { DbFieldIds.AnalyticsIds.PageLevelTestDefinitionField, "__Page Level Test Set Definition" },
             { DbFieldIds.AnalyticsIds.TrackingField, "__Tracking" },


### PR DESCRIPTION
Added to the fake standard template (made sure we have our own constant - similar to `__Final Renderings` to compile under earlier versions). That's all I had to do. Cloning is not done via a command - it's implemented directly on the `Item`. Just had to make sure our items were ready to receive writes into the new `FieldIDs.SourceItem` field.