### PR TITLE
Fix #138

### DIFF
--- a/src/Sitecore.FakeDb/Data/Engines/DataCommands/AddFromTemplateCommand.cs
+++ b/src/Sitecore.FakeDb/Data/Engines/DataCommands/AddFromTemplateCommand.cs
@@ -28,9 +28,9 @@
     protected override Item DoExecute()
     {
       var item = new DbItem(this.ItemName, this.NewId, this.TemplateId) { ParentID = this.Destination.ID };
-      this.dataStorage.AddFakeItem(item);
+      this.dataStorage.AddFakeItem(item, this.Destination.Language);
 
-      return this.dataStorage.GetSitecoreItem(this.NewId);
+      return this.dataStorage.GetSitecoreItem(this.NewId, this.Destination.Language);
     }
   }
 }

--- a/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
+++ b/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
@@ -55,6 +55,11 @@ namespace Sitecore.FakeDb.Data.Engines
 
     public virtual void AddFakeItem(DbItem item)
     {
+      this.AddFakeItem(item, Language.Current);
+    }
+
+    public virtual void AddFakeItem(DbItem item, Language language)
+    {
       Assert.ArgumentNotNull(item, "item");
 
       var loading = item is IDsDbItem;
@@ -78,7 +83,7 @@ namespace Sitecore.FakeDb.Data.Engines
         CorePipeline.Run("loadDsDbItem", new DsItemLoadingArgs(item as IDsDbItem, this));
       }
 
-      CorePipeline.Run("addDbItem", new AddDbItemArgs(item, this));
+      CorePipeline.Run("addDbItem", new AddDbItemArgs(item, this, language));
 
       if (!loading)
       {

--- a/src/Sitecore.FakeDb/Pipelines/AddDbItem/AddDbItemArgs.cs
+++ b/src/Sitecore.FakeDb/Pipelines/AddDbItem/AddDbItemArgs.cs
@@ -4,6 +4,7 @@
   using Sitecore.Diagnostics;
   using Sitecore.FakeDb.Data.Engines;
   using Sitecore.Pipelines;
+  using Sitecore.Globalization;
 
   public class AddDbItemArgs : PipelineArgs
   {
@@ -11,13 +12,21 @@
 
     private readonly DataStorage dataStorage;
 
-    public AddDbItemArgs(DbItem item, DataStorage dataStorage)
+    private readonly Language language;
+
+    public AddDbItemArgs(DbItem item, DataStorage dataStorage) : this(item, dataStorage, Language.Current)
+    {
+    }
+
+    public AddDbItemArgs(DbItem item, DataStorage dataStorage, Language language)
     {
       Assert.ArgumentNotNull(item, "item");
       Assert.ArgumentNotNull(dataStorage, "dataStorage");
+      Assert.ArgumentNotNull(language, "language");
 
       this.item = item;
       this.dataStorage = dataStorage;
+      this.language = language;
     }
 
     public ID DefaultItemRoot
@@ -38,6 +47,11 @@
     public DataStorage DataStorage
     {
       get { return this.dataStorage; }
+    }
+
+    public Language Language
+    {
+      get { return this.language; }
     }
   }
 }

--- a/src/Sitecore.FakeDb/Pipelines/AddDbItem/AddVersion.cs
+++ b/src/Sitecore.FakeDb/Pipelines/AddDbItem/AddVersion.cs
@@ -6,7 +6,7 @@
   {
     public virtual void Process(AddDbItemArgs args)
     {
-      args.DbItem.AddVersion(Language.Current.Name);
+      args.DbItem.AddVersion(args.Language.Name);
     }
   }
 }

--- a/test/Sitecore.FakeDb.Tests/Data/Engines/DataCommands/AddFromTemplateCommandTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Engines/DataCommands/AddFromTemplateCommandTest.cs
@@ -6,6 +6,7 @@
   using Sitecore.Data.Items;
   using Sitecore.FakeDb.Data.Engines.DataCommands;
   using Sitecore.Reflection;
+  using Sitecore.Globalization;
   using Xunit;
 
   public class AddFromTemplateCommandTest
@@ -23,14 +24,15 @@
       sut.DataStorage.Received().AddFakeItem(Arg.Is<DbItem>(i => i.Name == name &&
                                                                  i.ID == newId &&
                                                                  i.TemplateID == templateId &&
-                                                                 i.ParentID == destination.ID));
+                                                                 i.ParentID == destination.ID),
+                                             Arg.Is<Language>(l => l.Name == Language.Current.Name));
     }
 
     [Theory, DefaultAutoData]
     public void ShouldReturnCreatedItem(AddFromTemplateCommand sut, Item item, Item destination)
     {
       // arrange
-      sut.DataStorage.GetSitecoreItem(item.ID).Returns(item);
+      sut.DataStorage.GetSitecoreItem(item.ID, item.Language).Returns(item);
       sut.Initialize(item.Name, item.TemplateID, destination, item.ID);
 
       // act

--- a/test/Sitecore.FakeDb.Tests/DbTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbTest.cs
@@ -96,6 +96,25 @@
     }
 
     [Fact]
+    public void ShouldCreateChildItemInSpecificLanguage()
+    {
+      // arrange
+      using (var db = new Db
+                        {
+                          new DbItem("home")
+                        })
+      {
+        var item = db.GetItem("/sitecore/content/home", Language.Parse("fr-FR").Name);
+
+        // act
+        var child = item.Add("child", item.Template);
+
+        // assert
+        child.Language.Name.Should().Be("fr-FR");
+      }
+    }
+
+    [Fact]
     public void ShouldCreateItemOfPredefinedTemplate()
     {
       // act

--- a/test/Sitecore.FakeDb.Tests/Pipelines/AddDbItem/AddVersionTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Pipelines/AddDbItem/AddVersionTest.cs
@@ -4,6 +4,7 @@
   using Sitecore.Data;
   using Sitecore.FakeDb.Data.Engines;
   using Sitecore.FakeDb.Pipelines.AddDbItem;
+  using Sitecore.Globalization;
   using Xunit;
 
   public class AddVersionTest
@@ -20,6 +21,20 @@
 
       // assert
       args.DbItem.GetVersionCount("en").Should().Be(1);
+    }
+
+    [Fact]
+    public void ShouldAddVersionInTheGivenLanguage()
+    {
+      // arrange
+      var processor = new AddVersion();
+      var args = new AddDbItemArgs(new DbItem("home"), new DataStorage(Database.GetDatabase("master")), Language.Parse("fr-FR"));
+
+      // act
+      processor.Process(args);
+
+      // assert
+      args.DbItem.GetVersionCount("fr-FR").Should().Be(1);
     }
   }
 }


### PR DESCRIPTION
I only wonder if we need to do the same for `CopyItemCommand` and `CreateItemCommand`. Need to run a few tests against vanilla Sitecore to understand how those commands work in case the destination item is not in the `Language.Current` 