### PR TITLE
Introduce 'databaseType' config variable for switching to Sitecore 8.2

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,3 @@
+%WINDIR%/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe Build.msbuild /p:Configuration=Release /t:Versions /p:NoWarn=1591 /p:TargetFrameworkVersion=v4.5.2 /p:SupportedSitecoreVersions=SC820 /p:PatchDatabase=true
+if %errorlevel% neq 0 exit /b %errorlevel%
 %WINDIR%/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe Build.msbuild /p:Configuration=Release /t:Versions /p:NoWarn=1591

--- a/build.msbuild
+++ b/build.msbuild
@@ -9,7 +9,12 @@
     <Versions Include="$(SupportedSitecoreVersions)" />
     <References Include="lib\$(Version)\*.dll" />
     <CleanUp Include="lib\*.dll" />
+    <CleanUp Include="test\**\Sitecore.FakeDb.Tests.config" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <PatchDatabase>false</PatchDatabase>
+  </PropertyGroup>
 
   <Target Name="Clean">
     <MSBuild Projects="$(ProjectToBuild)" Targets="Clean" />
@@ -43,6 +48,15 @@
   </ItemGroup>
 
   <Target Name="Tests" DependsOnTargets="Compile">
+    <Message Text="=== RUNNING TESTS FOR $(Version) ===" Importance="high" />
+    
+    <!-- Patch database type for SC82 -->
+    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="$(FakeDbTestsDir)\App_Config\Include" Condition="$(PatchDatabase)" />
+    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="$(AutoFixtureTestsDir)\App_Config\Include" Condition="$(PatchDatabase)" />
+    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="$(NSubstituteTestsDir)\App_Config\Include" Condition="$(PatchDatabase)" />
+    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="$(SerializationTestsDir)\App_Config\Include" Condition="$(PatchDatabase)" />
+    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="test\Sitecore.FakeDb.NUnitLite.Tests\App_Config\Include" Condition="$(PatchDatabase)" />
+
     <xunit Assemblies="@(TestAssemblies)" ParallelizeTestCollections="false" />
     <Exec Command="Sitecore.FakeDb.NUnitLite.Tests.exe" WorkingDirectory="test\Sitecore.FakeDb.NUnitLite.Tests\bin\Release" />
   </Target>

--- a/deploy.bat
+++ b/deploy.bat
@@ -3,6 +3,8 @@ setlocal
 :PROMPT
 SET /P AREYOUSURE=Are you sure you want to publish the NuGet packages (Y/[N])?
 IF /I "%AREYOUSURE%" NEQ "Y" GOTO END
+  %WINDIR%/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe Build.msbuild /p:Configuration=Release /t:Versions /p:NoWarn=1591 /p:TargetFrameworkVersion=v4.5.2 /p:SupportedSitecoreVersions=SC820 /p:PatchDatabase=true
+  if %errorlevel% neq 0 exit /b %errorlevel%
   %WINDIR%/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe Build.msbuild /p:Configuration=Release /t:Deploy /p:NoWarn=1591
 :END
 endlocal

--- a/lib/SC820/README.md
+++ b/lib/SC820/README.md
@@ -1,0 +1,13 @@
+# Required Files
+
+Copy the following DLLs from your Sitecore **8.2.0** `Website\bin`:
+
+* Lucene.Net.dll
+* Sitecore.Abstractions.dll
+* Sitecore.Analytics.dll
+* Sitecore.Buckets.dll
+* Sitecore.ContentSearch.dll
+* Sitecore.ContentSearch.Linq.dll
+* Sitecore.Kernel.dll
+* Sitecore.Logging.dll
+* sitecore.nexus.dll

--- a/lib/SC820/Sitecore.FakeDb.Tests.config
+++ b/lib/SC820/Sitecore.FakeDb.Tests.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+  <sitecore>
+    <sc.variable name="databaseType" value="Sitecore.Data.DefaultDatabase, Sitecore.Kernel" />
+  </sitecore>
+</configuration>

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -9,6 +9,13 @@
       <setting name="FakeDb.AutoTranslatePrefix" value="" />
       <setting name="FakeDb.AutoTranslateSuffix" value="" />
     </settings>
+    <!-- EVENTING -->
+    <eventing defaultProvider="sitecore">
+      <providers>
+        <clear />
+        <add name="sitecore" type="Sitecore.Eventing.EventProvider, Sitecore.Kernel" systemDatabaseName="core" />
+      </providers>
+    </eventing>
     <!-- LINK DATABASE -->
     <LinkDatabase type="Sitecore.FakeDb.Links.FakeLinkDatabase, Sitecore.FakeDb" />
     <!-- TASK DATABASE -->

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -58,21 +58,21 @@
     <!-- DATABASES -->
     <databases>
       <!-- core -->
-      <database id="core" type="Sitecore.Data.Database, Sitecore.Kernel" singleInstance="true">
+      <database id="core" type="$(databaseType)" singleInstance="true">
         <param desc="name">$(id)</param>
         <dataProviders hint="list:AddDataProvider">
           <dataProvider ref="dataProviders/main" />
         </dataProviders>
       </database>
       <!-- master -->
-      <database id="master" type="Sitecore.Data.Database, Sitecore.Kernel" singleInstance="true">
+      <database id="master" type="$(databaseType)" singleInstance="true">
         <param desc="name">$(id)</param>
         <dataProviders hint="list:AddDataProvider">
           <dataProvider ref="dataProviders/main" />
         </dataProviders>
       </database>
       <!-- web -->
-      <database id="web" type="Sitecore.Data.Database, Sitecore.Kernel" singleInstance="true">
+      <database id="web" type="$(databaseType)" singleInstance="true">
         <param desc="name">$(id)</param>
         <dataProviders hint="list:AddDataProvider">
           <dataProvider ref="dataProviders/main" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/SwitchingLinkProviderSample.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/SwitchingLinkProviderSample.cs
@@ -1,4 +1,4 @@
-﻿#if !SC72
+﻿#if !SC72 && !SC820
 namespace Sitecore.FakeDb.AutoFixture.Tests.Samples
 {
   using NSubstitute;

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -41,6 +41,14 @@
       <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -4,6 +4,8 @@
   <package id="AutoFixture.AutoNSubstitute" version="3.50.2" targetFramework="net45" />
   <package id="AutoFixture.Xunit2" version="3.50.2" targetFramework="net45" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
@@ -41,6 +41,14 @@
       <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
@@ -34,6 +34,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="NUnitLite" version="3.4.1" targetFramework="net45" />
 </packages>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -41,6 +41,14 @@
       <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="AutoFixture" version="3.50.2" targetFramework="net45" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/test/Sitecore.FakeDb.Tests/App.config
+++ b/test/Sitecore.FakeDb.Tests/App.config
@@ -11,6 +11,10 @@
     <settings>
       <setting name="LicenseFile" value="..\..\..\..\lib\license.xml" />
     </settings>
+    <!-- DATABASE TYPE
+         For Sitecore versions prior to 8.2 should be 'Sitecore.Data.Database, Sitecore.Kernel'.
+         For Sitecore 8.2 and later should be 'Sitecore.Data.DefaultDatabase, Sitecore.Kernel'. -->
+    <sc.variable name="databaseType" value="Sitecore.Data.Database, Sitecore.Kernel" />
   </sitecore>
   <log4net />
   <system.web>

--- a/test/Sitecore.FakeDb.Tests/GettingStarted.cs
+++ b/test/Sitecore.FakeDb.Tests/GettingStarted.cs
@@ -699,7 +699,7 @@
       }
     }
 
-#if !SC72
+#if !SC72 && !SC820
     [Fact]
     public void HowToSwitchLinkProvider()
     {

--- a/test/Sitecore.FakeDb.Tests/Links/LinkProviderSwitcherTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Links/LinkProviderSwitcherTest.cs
@@ -23,7 +23,7 @@
       LinkProviderSwitcher.CurrentValue.Should().BeSameAs(provider);
     }
 
-#if !SC72
+#if !SC72 && !SC820
     [Theory, AutoData]
     public void SutSwitchesSwitcherSitecoreLinkProvider([Frozen]LinkProvider provider, LinkProviderSwitcher sut)
     {
@@ -48,7 +48,7 @@
       {
 #if SC72
         LinkManager.Providers["switcher"].GetItemUrl(item, options).Should().Be("http://myawesomeurl.com");
-#else
+#elif !SC820
         LinkManager.GetItemUrl(item, options).Should().Be("http://myawesomeurl.com");
 #endif
       }

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -42,6 +42,14 @@
       <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -4,6 +4,8 @@
   <package id="AutoFixture.AutoNSubstitute" version="3.50.2" targetFramework="net45" />
   <package id="AutoFixture.Xunit2" version="3.50.2" targetFramework="net45" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
Addresses #139 introducing the `databaseType` variable:

```xml
<!-- DATABASE TYPE
     For Sitecore versions prior to 8.2 should be 'Sitecore.Data.Database, Sitecore.Kernel'.
     For Sitecore 8.2 and later should be 'Sitecore.Data.DefaultDatabase, Sitecore.Kernel'. -->
<sc.variable name="databaseType" value="Sitecore.Data.Database, Sitecore.Kernel" />
```