### PR TITLE
GetPublishQueue returns empty IDList if no thread local value specified

### DIFF
--- a/src/Sitecore.FakeDb/Data/DataProviders/FakeDataProvider.cs
+++ b/src/Sitecore.FakeDb/Data/DataProviders/FakeDataProvider.cs
@@ -22,7 +22,7 @@
     private readonly ThreadLocal<List<PublishQueueItem>> publishQueue = new ThreadLocal<List<PublishQueueItem>>();
 
     private readonly DataStorage dataStorage;
-    
+
     public FakeDataProvider()
     {
     }
@@ -70,6 +70,11 @@
 
     public override IDList GetPublishQueue(DateTime @from, DateTime to, CallContext context)
     {
+      if (this.publishQueue.Value == null)
+      {
+        return new IDList();
+      }
+
       return IDList.Build(
         this.publishQueue.Value
           .Where(i => i.Date >= @from && i.Date <= to)

--- a/test/Sitecore.FakeDb.Tests/Data/DataProviders/FakeDataProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/DataProviders/FakeDataProviderTest.cs
@@ -313,6 +313,15 @@
       result.ShouldBeEquivalentTo(new IDList { itemId1, itemId2 });
     }
 
+    [Theory, DefaultAutoData]
+    public void GetPublishQueueReturnsEmptyIDListIfNoItemsAdded(
+      [Greedy] FakeDataProvider sut,
+      CallContext context)
+    {
+      var result = sut.GetPublishQueue(DateTime.MinValue, DateTime.MaxValue, context);
+      result.Should().BeEmpty();
+    }
+
     [Theory]
     [InlineDefaultAutoData(-1, 0, 1)]
     [InlineDefaultAutoData(0, 0, 1)]


### PR DESCRIPTION
Fixes ArgumentNullException when the thread local publish queue [is not initialized](https://github.com/sergeyshushlyapin/Sitecore.FakeDb/issues/146#issuecomment-251693008) (#146).