### PR TITLE
Configure AppVeyor CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Sitecore FakeDb
 ===============
 
 [![#](https://img.shields.io/nuget/v/Sitecore.FakeDb.svg)](https://www.nuget.org/packages/Sitecore.FakeDb/)
+[![#](https://ci.appveyor.com/api/projects/status/hkain4398nd94420?svg=true)](https://ci.appveyor.com/project/sergeyshushlyapin/sitecore-fakedb)
 
 This is the unit testing framework for Sitecore that enables creation and manipulation of Sitecore content in memory. It is designed to minimize efforts for the test content initialization keeping focus on the minimal test data rather than comprehensive content tree representation.
 

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/AddContentDbItemCommandTest.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/AddContentDbItemCommandTest.cs
@@ -30,7 +30,7 @@
       action.ShouldNotThrow();
     }
 
-    [Fact]
+    [Fact, Trait("Category", "RequireLicense")]
     public void CreateAddsItemToDb()
     {
       var fixture = new Fixture();

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/AddContentItemCommandTest.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/AddContentItemCommandTest.cs
@@ -8,6 +8,7 @@
   using Sitecore.Data.Items;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class AddContentItemCommandTest
   {
     [Theory, AutoData]

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/AddContentTemplateItemCommandTest.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/AddContentTemplateItemCommandTest.cs
@@ -31,7 +31,7 @@
       action.ShouldNotThrow();
     }
 
-    [Fact]
+    [Fact, Trait("Category", "RequireLicense")]
     public void CreateAddsItemToDb()
     {
       var fixture = new Fixture();

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/AutoContentCustomizationTest.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/AutoContentCustomizationTest.cs
@@ -16,7 +16,7 @@
       action.ShouldThrow<ArgumentNullException>().WithMessage("*fixture");
     }
 
-    [Fact]
+    [Fact, Trait("Category", "RequireLicense")]
     public void CreatesTemplateItem()
     {
       var fixture = new Fixture();

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/AutoDbCustomizatonTest.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/AutoDbCustomizatonTest.cs
@@ -10,6 +10,7 @@
   using Sitecore.Rules;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class AutoDbCustomizatonTest
   {
     [Theory, AutoDbData]

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/ContentAttributeTest.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/ContentAttributeTest.cs
@@ -6,6 +6,7 @@
   using Ploeh.AutoFixture.Xunit2;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ContentAttributeTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/CustomTemplateTest.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/CustomTemplateTest.cs
@@ -6,10 +6,11 @@
   using Sitecore.Data.Items;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class CustomTemplateTest
   {
     [Theory, AutoDbData]
-    public void CreateItemBasedOnCustomTemplate([Content] Item root,[Content] MyHomeTemplate template)
+    public void CreateItemBasedOnCustomTemplate([Content] Item root, [Content] MyHomeTemplate template)
     {
       // act
       var home = root.Add("home", new TemplateID(template.ID));
@@ -37,6 +38,5 @@
         this.Add("Title");
       }
     }
- 
   }
 }

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/AutoDbCustomizationSamples.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/AutoDbCustomizationSamples.cs
@@ -5,6 +5,7 @@
   using Sitecore.Data.Items;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class AutoDbCustomizationSamples
   {
     [Fact]

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/AutoDbDataAttributeSamples.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/AutoDbDataAttributeSamples.cs
@@ -4,6 +4,7 @@
   using Sitecore.Data.Items;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class AutoDbDataAttributeSamples
   {
     [Theory, AutoDbData]

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/AutoDbTemplateSamples.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/AutoDbTemplateSamples.cs
@@ -4,6 +4,7 @@
   using Sitecore.Data.Items;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class AutoDbTemplateSamples
   {
     [Theory, AutoDbData]

--- a/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeExistingItem.cs
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeExistingItem.cs
@@ -18,6 +18,7 @@
     }
 
     [Fact(DisplayName = "Overwrites the existing item")]
+    [Trait("Category", "RequireLicense")]
     public void OverwriteExisting()
     {
       this.Db.Add(this.DeserializedItem);

--- a/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeItemAndAddDuplicate.cs
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeItemAndAddDuplicate.cs
@@ -20,6 +20,7 @@ namespace Sitecore.FakeDb.Serialization.Tests.Deserialize
     }
 
     [Fact(DisplayName = "Does not overwrite the deserialized item")]
+    [Trait("Category", "RequireLicense")]
     public void DoesNotOverwriteDeserializedItem()
     {
       try

--- a/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeNewItem.cs
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeNewItem.cs
@@ -12,6 +12,7 @@ namespace Sitecore.FakeDb.Serialization.Tests.Deserialize
     }
 
     [Fact(DisplayName = "Creates the new item")]
+    [Trait("Category", "RequireLicense")]
     public void CreateNewItem()
     {
       this.Db.GetItem(SerializationId.ContentHomeItem).Should().NotBeNull();

--- a/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeSystemItem.cs
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeSystemItem.cs
@@ -13,6 +13,7 @@ namespace Sitecore.FakeDb.Serialization.Tests.Deserialize
     }
 
     [Fact(DisplayName = "Puts item in the System folder")]
+    [Trait("Category", "RequireLicense")]
     public void PutsItemUnderValidRoot()
     {
       this.Db.GetItem(SerializationId.MySystemItem).Paths.FullPath.Should().Be("/sitecore/system/My System");

--- a/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeTree.cs
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Deserialize/DeserializeTree.cs
@@ -15,12 +15,14 @@
     }
 
     [Fact(DisplayName = "Deserializes templates in tree")]
+    [Trait("Category", "RequireLicense")]
     public void DeserializesTemplates()
     {
       Assert.NotNull(this.Db.Database.GetTemplate(SerializationId.SampleItemTemplate));
     }
 
     [Fact(DisplayName = "Deserializes items in tree")]
+    [Trait("Category", "RequireLicense")]
     public void DeserializesItems()
     {
       var nonTemplateItemCount =

--- a/test/Sitecore.FakeDb.Serialization.Tests/DsDbItemTest.cs
+++ b/test/Sitecore.FakeDb.Serialization.Tests/DsDbItemTest.cs
@@ -7,6 +7,7 @@
   using Sitecore.Globalization;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class DsDbItemTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Serialization.Tests/GettingStarted.cs
+++ b/test/Sitecore.FakeDb.Serialization.Tests/GettingStarted.cs
@@ -2,6 +2,7 @@
 {
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class GettingStarted
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/AutoFixture/AutoFixtrureTest.cs
+++ b/test/Sitecore.FakeDb.Tests/AutoFixture/AutoFixtrureTest.cs
@@ -4,6 +4,7 @@
   using Ploeh.AutoFixture.Xunit2;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class AutoFixtrureTest
   {
     [Theory, AutoData]

--- a/test/Sitecore.FakeDb.Tests/Data/BranchRecordsTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/BranchRecordsTest.cs
@@ -4,6 +4,7 @@
   using Sitecore.Data;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class BranchRecordsTest
   {
     private readonly ID branchId = ID.NewID;

--- a/test/Sitecore.FakeDb.Tests/Data/Clones/ClonesTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Clones/ClonesTest.cs
@@ -4,6 +4,7 @@
   using Sitecore.Data.Items;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ClonesTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Engines/DataCommands/MoveItemCommandTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Engines/DataCommands/MoveItemCommandTest.cs
@@ -10,6 +10,7 @@
   using Xunit;
   using MoveItemCommand = Sitecore.FakeDb.Data.Engines.DataCommands.MoveItemCommand;
 
+  [Trait("Category", "RequireLicense")]
   public class MoveItemCommandTest
   {
     [Theory, DefaultAutoData]

--- a/test/Sitecore.FakeDb.Tests/Data/Engines/DataStorageTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Engines/DataStorageTest.cs
@@ -152,6 +152,7 @@
     [InlineData("core", true)]
     [InlineData("master", false)]
     [InlineData("web", false)]
+    [Trait("Category", "RequireLicense")]
     public void ShouldCreateFieldTypesRootInCoreDatabase(string database, bool exists)
     {
       // arrange
@@ -199,45 +200,45 @@
       actual.ToArray().Should().BeEquivalentTo(@new.ToArray());
     }
 
-      [Theory, AutoData]
-      public void SetBlobStreamPositionAndLengthNotChanged(
-          Guid blobId,
-          [NoAutoProperties] MemoryStream @new,
-          string streamData)
-      {
-          var bytes = Encoding.UTF8.GetBytes(streamData);
-          @new.Write(bytes, 0, bytes.Length);
-          var position = bytes.Length/2;
-          var length = bytes.Length;
+    [Theory, AutoData]
+    public void SetBlobStreamPositionAndLengthNotChanged(
+        Guid blobId,
+        [NoAutoProperties] MemoryStream @new,
+        string streamData)
+    {
+      var bytes = Encoding.UTF8.GetBytes(streamData);
+      @new.Write(bytes, 0, bytes.Length);
+      var position = bytes.Length / 2;
+      var length = bytes.Length;
 
-          @new.Seek(position, SeekOrigin.Begin);
+      @new.Seek(position, SeekOrigin.Begin);
 
-          this.dataStorage.SetBlobStream(blobId, @new);
+      this.dataStorage.SetBlobStream(blobId, @new);
 
-          @new.Length.ShouldBeEquivalentTo(length);
-          @new.Position.ShouldBeEquivalentTo(position);
-      }
+      @new.Length.ShouldBeEquivalentTo(length);
+      @new.Position.ShouldBeEquivalentTo(position);
+    }
 
 
-      [Theory, AutoData]
-      public void SetBlobStreamFollowedByGetBlobStreamReturnStreamAtPosition0(
-          Guid blobId,
-          [NoAutoProperties] MemoryStream @new,
-          string streamData)
-      {
-          var bytes = Encoding.UTF8.GetBytes(streamData);
-          @new.Write(bytes, 0, bytes.Length);
+    [Theory, AutoData]
+    public void SetBlobStreamFollowedByGetBlobStreamReturnStreamAtPosition0(
+        Guid blobId,
+        [NoAutoProperties] MemoryStream @new,
+        string streamData)
+    {
+      var bytes = Encoding.UTF8.GetBytes(streamData);
+      @new.Write(bytes, 0, bytes.Length);
 
-          this.dataStorage.SetBlobStream(blobId, @new);
+      this.dataStorage.SetBlobStream(blobId, @new);
 
-          var copy1 = this.dataStorage.GetBlobStream(blobId);
+      var copy1 = this.dataStorage.GetBlobStream(blobId);
 
-          copy1.Position.ShouldBeEquivalentTo(0);
-          copy1.Length.ShouldBeEquivalentTo(bytes.Length);
-          copy1.Should().NotBe(@new);
-      }
+      copy1.Position.ShouldBeEquivalentTo(0);
+      copy1.Length.ShouldBeEquivalentTo(bytes.Length);
+      copy1.Should().NotBe(@new);
+    }
 
-      [Theory, AutoData]
+    [Theory, AutoData]
     public void SetBlobStreamThrowsIfStreamIsNull(Guid blobId)
     {
       Assert.Throws<ArgumentNullException>(() => this.dataStorage.SetBlobStream(blobId, null));

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/BlobFieldTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/BlobFieldTest.cs
@@ -5,6 +5,7 @@
   using Sitecore.Data.Items;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class BlobFieldTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/FieldTypeManagerTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/FieldTypeManagerTest.cs
@@ -5,6 +5,7 @@
   using Sitecore.Data.Fields;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class FieldTypeManagerTest
   {
     [Theory]

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/LayoutFieldTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/LayoutFieldTest.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Sitecore.FakeDb.Tests.Data.Fields
 {
+  [Trait("Category", "RequireLicense")]
   public class LayoutFieldTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/LinkFieldTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/LinkFieldTest.cs
@@ -9,6 +9,7 @@
   /// Internal link: <link text="Link to Home item" linktype="internal" class="default" title="Home" target='Active Browser' querystring="sc_lang=en" id="{110D559F-DEA5-42EA-9C1C-8A5DF7E70EF9}" />
   /// External link: <link text="Gmail" linktype="external" url="http://gmail.com" anchor="" title="Google mail" class="link" target="Active Browser" />
   /// </summary>
+  [Trait("Category", "RequireLicense")]
   public class LinkFieldTest
   {
     [Fact]
@@ -46,7 +47,7 @@
                             {
                               new DbLinkField("link")
                                 {
-                                  LinkType = "internal", 
+                                  LinkType = "internal",
                                   QueryString = "sc_lang=en",
                                   TargetID = targetId,
                                 }

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/ReferenceFieldTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/ReferenceFieldTest.cs
@@ -5,6 +5,7 @@
   using Sitecore.Data.Fields;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ReferenceFieldTest
   {
     [Fact]
@@ -14,7 +15,7 @@
       var targetId = ID.NewID;
 
       using (var db = new Db
-                        { 
+                        {
                            new DbItem("source") { { "Reference", "/sitecore/content/target" } },
                            new DbItem("target",  targetId)
                         })
@@ -33,6 +34,7 @@
         referenceField.TargetItem.Should().Be(db.GetItem(targetId));
       }
     }
+
     [Fact]
     public void ShouldGetTargetById()
     {
@@ -40,7 +42,7 @@
       var targetId = ID.NewID;
 
       using (var db = new Db
-                        { 
+                        {
                            new DbItem("source") { { "Reference", targetId.ToString() } },
                            new DbItem("target",  targetId)
                         })

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/SecurityFieldTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/SecurityFieldTest.cs
@@ -3,6 +3,7 @@
   using FluentAssertions;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class SecurityFieldTest
   {
     private const string AllowAllAccessRule = "ar|Everyone|p*|+*|";
@@ -24,7 +25,7 @@
     public void ShouldSetSecurityFieldByName()
     {
       // arrange & act
-      using (var db = new Db 
+      using (var db = new Db
                         {
                           new DbItem("home") { { "__Security", AllowAllAccessRule } }
                         })
@@ -40,7 +41,7 @@
     public void ShouldSetSecurityFieldById()
     {
       // arrange & act
-      using (var db = new Db 
+      using (var db = new Db
                         {
                           new DbItem("home") { new DbField(FieldIDs.Security) { Value = AllowAllAccessRule } }
                         })

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/StandardFieldsTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/StandardFieldsTest.cs
@@ -4,6 +4,7 @@
   using Ploeh.AutoFixture.Xunit2;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class StandardFieldsTest
   {
     [Theory]

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/StatisticsFieldsTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/StatisticsFieldsTest.cs
@@ -4,6 +4,7 @@
   using Sitecore.Data;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class StatisticsFieldsTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Items/ItemAppearanceTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Items/ItemAppearanceTest.cs
@@ -2,9 +2,9 @@
 {
   using FluentAssertions;
   using Sitecore.Data.Items;
-  using Sitecore.Globalization;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ItemAppearanceTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Items/ItemStatisticsTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Items/ItemStatisticsTest.cs
@@ -6,6 +6,7 @@
   using Sitecore.SecurityModel;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ItemStatisticsTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Items/ItemVersionsTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Items/ItemVersionsTest.cs
@@ -3,6 +3,7 @@
   using FluentAssertions;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ItemVersionsTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Locking/ItemLockingTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Locking/ItemLockingTest.cs
@@ -4,6 +4,7 @@
   using Sitecore.Security.Accounts;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ItemLockingTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Managers/ItemManagerTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Managers/ItemManagerTest.cs
@@ -6,6 +6,7 @@
   using Sitecore.Data.Managers;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ItemManagerTest
   {
     private readonly ID templateId = ID.NewID;

--- a/test/Sitecore.FakeDb.Tests/Data/Query/FastQueryTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Query/FastQueryTest.cs
@@ -3,6 +3,7 @@
   using FluentAssertions;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class FastQueryTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Query/QueryTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Query/QueryTest.cs
@@ -6,6 +6,7 @@
   using Sitecore.Data.Query;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class QueryTest
   {
     [Theory]

--- a/test/Sitecore.FakeDb.Tests/Data/Templates/TemplatesTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Templates/TemplatesTest.cs
@@ -7,6 +7,7 @@
   using Sitecore.Data.Items;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class TemplatesTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/DbConcurrencyTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbConcurrencyTest.cs
@@ -11,6 +11,7 @@
   using Sitecore.Pipelines;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class DbConcurrencyTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/DbItemCopyingTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbItemCopyingTest.cs
@@ -4,6 +4,7 @@
   using FluentAssertions;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class DbItemCopyingTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/DbItemEditingTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbItemEditingTest.cs
@@ -6,9 +6,9 @@
   using Sitecore.Data.Managers;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class DbItemEditingTest
   {
-
     private readonly ID itemId = ID.NewID;
 
     private readonly ID templateId = ID.NewID;

--- a/test/Sitecore.FakeDb.Tests/DbStandardValuesTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbStandardValuesTest.cs
@@ -5,6 +5,7 @@
   using Sitecore.Data.Managers;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class DbStandardValuesTest
   {
     private readonly ID templateId = ID.NewID;

--- a/test/Sitecore.FakeDb.Tests/DbTemplateInheritanceTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbTemplateInheritanceTest.cs
@@ -10,6 +10,7 @@
   using Sitecore.Exceptions;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class DbTemplateInheritanceTest
   {
     private readonly DbTemplate baseTemplateOne;
@@ -23,9 +24,9 @@
       this.baseTemplateOne = new DbTemplate("Base One", ID.NewID) { "Title" };
       this.baseTemplateTwo = new DbTemplate("Base Two", ID.NewID) { "Description" };
       this.baseTemplateThree = new DbTemplate("Base Three", ID.NewID)
-        {
-          BaseIDs = new[] { this.baseTemplateTwo.ID }
-        };
+      {
+        BaseIDs = new[] { this.baseTemplateTwo.ID }
+      };
     }
 
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/DbTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbTest.cs
@@ -22,6 +22,7 @@
   using Xunit;
   using Version = Sitecore.Data.Version;
 
+  [Trait("Category", "RequireLicense")]
   public class DbTest
   {
     private readonly ID itemId = ID.NewID;

--- a/test/Sitecore.FakeDb.Tests/GettingStarted.cs
+++ b/test/Sitecore.FakeDb.Tests/GettingStarted.cs
@@ -5,6 +5,7 @@
   using Sitecore.Configuration;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class GettingStarted
   {
     #region Content

--- a/test/Sitecore.FakeDb.Tests/Links/LinkManagerTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Links/LinkManagerTest.cs
@@ -4,6 +4,7 @@
   using Sitecore.Links;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class LinkManagerTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Links/SwitchingLinkProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Links/SwitchingLinkProviderTest.cs
@@ -111,6 +111,7 @@
     }
 
     [Theory, SwitchingAutoData]
+    [Trait("Category", "RequireLicense")]
     public void GetItemUrlOptionsCallsBaseProviderIfCurrentNotSet(SwitchingLinkProvider sut, Item item, UrlOptions options)
     {
       using (new Db())

--- a/test/Sitecore.FakeDb.Tests/Pipelines/AddDbItem/CreateTemplateTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Pipelines/AddDbItem/CreateTemplateTest.cs
@@ -9,6 +9,7 @@
   using Sitecore.FakeDb.Pipelines.AddDbItem;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class CreateTemplateTest
   {
     private const string NullTemplateId = "{00000000-0000-0000-0000-000000000000}";

--- a/test/Sitecore.FakeDb.Tests/Runtime/FluentAssertionsTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Runtime/FluentAssertionsTest.cs
@@ -4,6 +4,7 @@
   using FluentAssertions;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class FluentAssertionsTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Security/AccessControl/AuthorizationSwitcherTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/AccessControl/AuthorizationSwitcherTest.cs
@@ -7,6 +7,7 @@
   using Sitecore.Security.Accounts;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class AuthorizationSwitcherTest
   {
     private readonly AuthorizationProvider provider = Substitute.For<AuthorizationProvider>();

--- a/test/Sitecore.FakeDb.Tests/Security/AccessControl/ItemSecurityTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/AccessControl/ItemSecurityTest.cs
@@ -4,6 +4,7 @@
   using Sitecore.Security.AccessControl;
   using Xunit;
 
+  [Trait("Category", "RequireLicense")]
   public class ItemSecurityTest
   {
     [Fact]


### PR DESCRIPTION
Configure [AppVeyor CI](https://ci.appveyor.com/) in order to check if the source code is compilable and *unit* tests pass.

Since there is no Sitecore license that could be stored on a third-party CI server, only those tests that do not require `license.xml` are executed. For that purpose new test category `RequireLicense` is introduced.