### PR TITLE
Upgrade FakeDb to Sitecore 8.2 Update-1

### DIFF
--- a/src/Sitecore.FakeDb/Links/LinkProviderSwitcher.cs
+++ b/src/Sitecore.FakeDb/Links/LinkProviderSwitcher.cs
@@ -1,8 +1,13 @@
 ﻿namespace Sitecore.FakeDb.Links
 {
+  using System;
   using Sitecore.Common;
   using Sitecore.Links;
 
+  [Obsolete("This class is not supported starting from Sitecore 8.2.0. " +
+            "Instead of switching the LinkProvider, please consider injecting " +
+            "the Sitecore.Abstractions.BaseLinkManager class into your System " +
+            "Under Test (SUT) via constructor.")]
   public class LinkProviderSwitcher : Switcher<LinkProvider>
   {
 #if !SC72160123

--- a/src/Sitecore.FakeDb/Links/SwitchingLinkProvider.cs
+++ b/src/Sitecore.FakeDb/Links/SwitchingLinkProvider.cs
@@ -1,11 +1,16 @@
 namespace Sitecore.FakeDb.Links
 {
+  using System;
   using System.Web;
   using Sitecore.Common;
   using Sitecore.Data.Items;
   using Sitecore.Links;
   using Sitecore.Web;
 
+  [Obsolete("This class is not supported starting from Sitecore 8.2.0. " +
+            "Instead of switching the LinkProvider, please consider injecting " +
+            "the Sitecore.Abstractions.BaseLinkManager class into your System " +
+            "Under Test (SUT) via constructor.")]
   public class SwitchingLinkProvider : LinkProvider
   {
     public LinkProvider CurrentProvider

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/SwitchingLinkProviderSample.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/SwitchingLinkProviderSample.cs
@@ -1,6 +1,7 @@
 ﻿#if !SC72160123 && !SC82160729 && !SC82161115
 namespace Sitecore.FakeDb.AutoFixture.Tests.Samples
 {
+  using System;
   using NSubstitute;
   using Ploeh.AutoFixture;
   using Ploeh.AutoFixture.AutoNSubstitute;
@@ -16,6 +17,7 @@ namespace Sitecore.FakeDb.AutoFixture.Tests.Samples
   // PM> Install-Package AutoFixture.Xunit2
   // PM> Install-Package AutoFixture.AutoNSubstitute
   // PM> Install-Package Sitecore.FakeDb.AutoFixture
+  [Obsolete("LinkProviderSwitcher is obsolete.")]
   public class SwitchingLinkProviderSample
   {
     [Theory, DefaultAutoData]

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/SwitchingLinkProviderSample.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/SwitchingLinkProviderSample.cs
@@ -1,4 +1,4 @@
-﻿#if !SC72160123 && !SC82160729
+﻿#if !SC72160123 && !SC82160729 && !SC82161115
 namespace Sitecore.FakeDb.AutoFixture.Tests.Samples
 {
   using NSubstitute;

--- a/test/Sitecore.FakeDb.Tests/GettingStarted.cs
+++ b/test/Sitecore.FakeDb.Tests/GettingStarted.cs
@@ -700,7 +700,7 @@
       }
     }
 
-#if !SC72160123 && !SC82160729
+#if !SC72160123 && !SC82160729 && !SC82161115
     [Fact]
     public void HowToSwitchLinkProvider()
     {

--- a/test/Sitecore.FakeDb.Tests/GettingStarted.cs
+++ b/test/Sitecore.FakeDb.Tests/GettingStarted.cs
@@ -1,5 +1,6 @@
 ﻿namespace Examples
 {
+  using System;
   using System.Linq;
   using NSubstitute;
   using Sitecore.Configuration;
@@ -701,6 +702,7 @@
     }
 
 #if !SC72160123 && !SC82160729 && !SC82161115
+    [Obsolete("LinkProviderSwitcher is obsolete.")]
     [Fact]
     public void HowToSwitchLinkProvider()
     {

--- a/test/Sitecore.FakeDb.Tests/Links/LinkProviderSwitcherTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Links/LinkProviderSwitcherTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace Sitecore.FakeDb.Tests.Links
 {
+  using System;
   using FluentAssertions;
   using NSubstitute;
   using Ploeh.AutoFixture.Xunit2;
@@ -9,6 +10,7 @@
   using Xunit;
   using LinkProviderSwitcher = Sitecore.FakeDb.Links.LinkProviderSwitcher;
 
+  [Obsolete("LinkProviderSwitcher is obsolete.")]
   public class LinkProviderSwitcherTest
   {
     [Theory, AutoData]

--- a/test/Sitecore.FakeDb.Tests/Links/LinkProviderSwitcherTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Links/LinkProviderSwitcherTest.cs
@@ -23,7 +23,7 @@
       LinkProviderSwitcher.CurrentValue.Should().BeSameAs(provider);
     }
 
-#if !SC72160123 && !SC82160729
+#if !SC72160123 && !SC82160729 && !SC82161115
     [Theory, AutoData]
     public void SutSwitchesSwitcherSitecoreLinkProvider([Frozen]LinkProvider provider, LinkProviderSwitcher sut)
     {
@@ -48,7 +48,7 @@
       {
 #if SC72160123
         LinkManager.Providers["switcher"].GetItemUrl(item, options).Should().Be("http://myawesomeurl.com");
-#elif !SC82160729
+#elif !SC82160729 && !SC82161115
         LinkManager.GetItemUrl(item, options).Should().Be("http://myawesomeurl.com");
 #endif
       }

--- a/test/Sitecore.FakeDb.Tests/Links/SwitchingLinkProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Links/SwitchingLinkProviderTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace Sitecore.FakeDb.Tests.Links
 {
+  using System;
   using System.Collections.Specialized;
   using System.Web;
   using FluentAssertions;
@@ -16,6 +17,7 @@
   using Xunit;
   using StringDictionary = Sitecore.Collections.StringDictionary;
 
+  [Obsolete("SwitchingLinkProvider is obsolete.")]
   public class SwitchingLinkProviderTest
   {
     [Theory, AutoData]

--- a/test/Sitecore.FakeDb.Tests/Security/Authentication/AuthenticationManagerTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/Authentication/AuthenticationManagerTest.cs
@@ -1,11 +1,28 @@
 ﻿namespace Sitecore.FakeDb.Tests.Security.Authentication
 {
+  using System;
   using FluentAssertions;
   using NSubstitute;
   using Sitecore.Security.Accounts;
   using Sitecore.Security.Authentication;
   using Xunit;
 
+#if !SC82161115
+  /// <summary>
+  /// Disable the entire test for Sitecore 8.2.1 and later because the 
+  /// existing functionality relies on provider switching which is no longer 
+  /// supported. Starting from Sitecore 8.2.1, the providers used by static 
+  /// managers have been obsoleted. One have to mock new abstractions 
+  /// created for each of the old static managers. For instance, in order to
+  /// mock the <see cref="AuthenticationManager"/> one have to inject
+  /// <see cref="Sitecore.Abstractions.BaseAuthenticationManager"/> into SUT.
+  /// In production, the default implementation will be injected using new
+  /// Sitecore DI.
+  /// 
+  /// Please go to the following thread for details:
+  /// https://github.com/sergeyshushlyapin/Sitecore.FakeDb/issues/154
+  /// </summary>
+  [Obsolete("Not supported in Sitecore 8.2.1 and later.")]
   public class AuthenticationManagerTest
   {
     private readonly AuthenticationProvider provider;
@@ -107,4 +124,5 @@
       }
     }
   }
+#endif
 }

--- a/version.props
+++ b/version.props
@@ -5,6 +5,6 @@
          run tests against before publishing the NuGet packages.
     -->
     <SupportedSitecoreVersions>7.2.160123;8.0.160115;8.1.160519</SupportedSitecoreVersions>
-    <SupportedSitecoreVersions452>8.2.160729</SupportedSitecoreVersions452>
+    <SupportedSitecoreVersions452>8.2.160729;8.2.161115</SupportedSitecoreVersions452>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Sitecore 8.2.1 has been [released to public](https://dev.sitecore.net/Downloads/Sitecore_Experience_Platform/82/Sitecore_Experience_Platform_82_Update1.aspx) recently. In order to check if FakeDb is compatible with that, the version needs to be added to the [list of supported versions](https://github.com/sergeyshushlyapin/Sitecore.FakeDb/blob/sc821/version.props).  FakeDb tests are executed against each of the supported versions before any [public release](https://www.nuget.org/packages/Sitecore.FakeDb/).

There are the following limitations for Sitecore 8.2.1:
1. `LinkProviderSwitcher` is no longer supported (related to #153)
2. `AuthenticationSwitcher` is no longer supported

The reason for that is the [new Sitecore DI](http://kamsar.net/index.php/2016/08/Dependency-Injection-in-Sitecore-8-2/) which deprecates _Providers_ as a whole. Prior to 8.2 there were static managers and configurable providers. The static managers couldn't be injected into the code (simply because they are static) which made unit testing in Sitecore so challenging.

FakeDb overcome that introducing so called _Switching_ providers, such as [SwitchingLinkProvider](https://github.com/sergeyshushlyapin/Sitecore.FakeDb/blob/87d2206e07dad5ee8e6e557f3e687ec8402d1b40/src/Sitecore.FakeDb/Links/SwitchingLinkProvider.cs). The idea behind is pretty simple. There is a single switching provider registered in a config, but the _actual_ value can be [substituted in a test](https://github.com/sergeyshushlyapin/Sitecore.FakeDb/wiki/Mocking-the-RolesInRoles-Provider) with a test double using `Sitecore.Common.Switcher<T>`.

Now Sitecore makes managers abstract (see `Sitecore.Abstractions` namespace in the Kernel) so that there is no need to substitute providers in such a tricky way. It is possible to inject let's say `Sitecore.Abstractions.BaseLinkManager` class into your code via constructor.

I see no reason to continue developing new _Switching Managers_ for 8.2+ versions. I did a prototype [here](https://github.com/sergeyshushlyapin/Sitecore.FakeDb/commit/ba5975f80cae70f1f0ee316bb1a81f13be587116#diff-1df2bbaf1816c4e317c32f4064eadcef), it's possible, but I think developers should start injecting the abstractions into their SUTs via constructors rather than using statics in combination with FakeDb.