### PR TITLE
Generate item statistics for all the specified languages (#155)

### DIFF
--- a/src/Sitecore.FakeDb/Pipelines/AddDbItem/SetStatistics.cs
+++ b/src/Sitecore.FakeDb/Pipelines/AddDbItem/SetStatistics.cs
@@ -1,5 +1,6 @@
 ﻿namespace Sitecore.FakeDb.Pipelines.AddDbItem
 {
+  using System.Linq;
   using Sitecore.Data;
 
   public class SetStatistics
@@ -13,9 +14,25 @@
 
       item.Fields.Add(new DbField("__Created", FieldIDs.Created) { Value = date });
       item.Fields.Add(new DbField("__Created by", FieldIDs.CreatedBy) { Value = user });
-      item.Fields.Add(new DbField("__Revision", FieldIDs.Revision) { Value = ID.NewID.ToString() });
+      item.Fields.Add(new DbField("__Revision", FieldIDs.Revision));
       item.Fields.Add(new DbField("__Updated", FieldIDs.Updated) { Value = date });
       item.Fields.Add(new DbField("__Updated by", FieldIDs.UpdatedBy) { Value = user });
+
+      SetRevisionForAllLanguages(item);
+    }
+
+    private static void SetRevisionForAllLanguages(DbItem item)
+    {
+      foreach (var lang in item.Fields.SelectMany(field => field.Values))
+      {
+        var revisionField = item.Fields[FieldIDs.Revision];
+        var revisionSet = !string.IsNullOrEmpty(
+          revisionField.GetValue(lang.Key, Version.Latest.Number));
+        if (!revisionSet)
+        {
+          revisionField.SetValue(lang.Key, ID.NewID.ToString());
+        }
+      }
     }
   }
 }

--- a/src/Sitecore.FakeDb/Pipelines/AddDbItem/SetStatistics.cs
+++ b/src/Sitecore.FakeDb/Pipelines/AddDbItem/SetStatistics.cs
@@ -3,6 +3,17 @@
   using System.Linq;
   using Sitecore.Data;
 
+  /// <summary>
+  /// Creates and fulfills item statistics fields for all the item languages.
+  /// The fields included are 'Created', 'CreatedBy', 'Revision', 'Updated' 
+  /// and 'UpdatedBy'.
+  /// <para>
+  /// The 'Created' and 'Updated' fields are set to the current date in ISO 
+  /// format. The 'CreatedBy' and 'UpdatedBy' fields store the current user 
+  /// name. The 'Revision' field is a <see cref="System.Guid"/> generated for
+  /// each of the item languages.
+  /// </para>
+  /// </summary>
   public class SetStatistics
   {
     public virtual void Process(AddDbItemArgs args)

--- a/test/Sitecore.FakeDb.Tests/DbTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbTest.cs
@@ -1768,5 +1768,21 @@
         targetItem.BranchId.Should().Be(branchId);
       }
     }
+
+    [Fact]
+    public void ShouldGetVersionedItemRevision()
+    {
+      using (var db = new Db
+        {
+          new DbItem("Home")
+            {
+              new DbField("Value") {{"af-ZA", 1, "test"}}
+            }
+        })
+      {
+        var item = db.GetItem("/sitecore/content/home", "af-ZA");
+        item["__Revision"].Should().NotBeNullOrEmpty();
+      }
+    }
   }
 }

--- a/test/Sitecore.FakeDb.Tests/Pipelines/SetStatisticsTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Pipelines/SetStatisticsTest.cs
@@ -8,6 +8,12 @@
 
   public class SetStatisticsTest
   {
+    private const string Created = "{25BED78C-4957-4165-998A-CA1B52F67497}";
+    private const string CreatedBy = "{5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}";
+    private const string Revision = "{8CDC337E-A112-42FB-BBB4-4143751E123F}";
+    private const string Updated = "{D9CF14B1-FA16-4BA6-9288-E8A174D4D522}";
+    private const string UpdatedBy = "{BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}";
+
     [Theory, DefaultAutoData]
     public void ProcessSetsUniqueRevisionsForAllLanguages(
       SetStatistics sut,
@@ -47,6 +53,54 @@
       var actual = item.Fields[FieldIDs.Revision].GetValue("en", 0);
 
       Assert.True(ID.IsID(actual));
+    }
+
+    [Theory]
+    [InlineDefaultAutoData(Created)]
+    [InlineDefaultAutoData(CreatedBy)]
+    [InlineDefaultAutoData(Updated)]
+    [InlineDefaultAutoData(UpdatedBy)]
+    public void ProcessSetsSameCreateAndUpdateInfoForAllLanguages(
+      string statisticField,
+      SetStatistics sut,
+      [Frozen] DbItem item,
+      AddDbItemArgs args,
+      ID id1,
+      ID id2,
+      string value1,
+      string value2)
+    {
+      var statisticFieldId = ID.Parse(statisticField);
+      var fieldEn = new DbField(id1) { { "en", value1 } };
+      var fieldDa = new DbField(id2) { { "da", value2 } };
+      item.Fields.Add(fieldEn);
+      item.Fields.Add(fieldDa);
+
+      sut.Process(args);
+      var valueEn = item.Fields[statisticFieldId].GetValue("en", 0);
+      var valueDa = item.Fields[statisticFieldId].GetValue("da", 0);
+
+      valueEn.Should().Be(valueDa);
+    }
+
+    [Theory]
+    [InlineDefaultAutoData(Created)]
+    [InlineDefaultAutoData(CreatedBy)]
+    [InlineDefaultAutoData(Revision)]
+    [InlineDefaultAutoData(Updated)]
+    [InlineDefaultAutoData(UpdatedBy)]
+    public void ProcessSetsStatisticsForItemWithoutFieldsInDefaultLanguage(
+      string statisticField,
+      SetStatistics sut,
+      [Frozen] DbItem item,
+      AddDbItemArgs args)
+    {
+      var statisticFieldId = ID.Parse(statisticField);
+
+      sut.Process(args);
+      var value = item.Fields[statisticFieldId].GetValue("en", 0);
+
+      value.Should().NotBeNullOrEmpty();
     }
   }
 }

--- a/test/Sitecore.FakeDb.Tests/Pipelines/SetStatisticsTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Pipelines/SetStatisticsTest.cs
@@ -1,0 +1,52 @@
+﻿namespace Sitecore.FakeDb.Tests.Pipelines
+{
+  using FluentAssertions;
+  using Ploeh.AutoFixture.Xunit2;
+  using Sitecore.Data;
+  using Sitecore.FakeDb.Pipelines.AddDbItem;
+  using Xunit;
+
+  public class SetStatisticsTest
+  {
+    [Theory, DefaultAutoData]
+    public void ProcessSetsUniqueRevisionsForAllLanguages(
+      SetStatistics sut,
+      [Frozen] DbItem item,
+      AddDbItemArgs args,
+      ID id1,
+      ID id2,
+      string value1,
+      string value2)
+    {
+      var fieldEn = new DbField(id1) { { "en", value1 } };
+      var fieldDa = new DbField(id2) { { "da", value2 } };
+      item.Fields.Add(fieldEn);
+      item.Fields.Add(fieldDa);
+
+      sut.Process(args);
+      var revisionEn = item.Fields[FieldIDs.Revision].GetValue("en", 0);
+      var revisionDa = item.Fields[FieldIDs.Revision].GetValue("da", 0);
+
+      revisionEn.Should().NotBeNullOrEmpty();
+      revisionDa.Should().NotBeNullOrEmpty();
+      revisionEn.Should().NotBe(revisionDa);
+    }
+
+    [Theory, DefaultAutoData]
+    public void ProcessSetsValidRevision(
+      SetStatistics sut,
+      [Frozen] DbItem item,
+      AddDbItemArgs args,
+      ID id,
+      string value)
+    {
+      var field = new DbField(id) { { "en", value } };
+      item.Fields.Add(field);
+
+      sut.Process(args);
+      var actual = item.Fields[FieldIDs.Revision].GetValue("en", 0);
+
+      Assert.True(ID.IsID(actual));
+    }
+  }
+}

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Pipelines\AddDbItem\SetWorkflowTest.cs" />
     <Compile Include="Pipelines\CorePipelineFactoryTest.cs" />
     <Compile Include="Pipelines\CorePipelineTest.cs" />
+    <Compile Include="Pipelines\SetStatisticsTest.cs" />
     <Compile Include="Profile\UserProfileTest.cs" />
     <Compile Include="Runtime\FluentAssertionsTest.cs" />
     <Compile Include="Samples\ContentSearchSamples.cs" />


### PR DESCRIPTION
Addresses #155.

The [`SetStatistics`](https://github.com/sergeyshushlyapin/Sitecore.FakeDb/blob/master/src/Sitecore.FakeDb/Pipelines/AddDbItem/SetStatistics.cs#L5) processor has been extended to generate item statistics for all the item languages discovered. Created and Updated fields are the same for all the languages, Revision is unique per language.