### PR TITLE
Add Sitecore 'ItemNameValidation' setting

### DIFF
--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -4,6 +4,7 @@
     <settings>
       <setting name="LicenseFile" value="license.xml" />
       <setting name="Caching.Enabled" value="false" />
+      <setting name="ItemNameValidation" value="^[\w\*\$][\w\s\-\$]*(\(\d{1,}\)){0,1}$" />
       <setting name="MaxWorkerThreads" value="0" />
       <setting name="FakeDb.AutoTranslate" value="false" />
       <setting name="FakeDb.AutoTranslatePrefix" value="" />

--- a/test/Sitecore.FakeDb.Tests/DbTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbTest.cs
@@ -1810,5 +1810,15 @@
             new[] { Language.Parse("en"), Language.Parse("da") });
       }
     }
+
+    [Fact]
+    public void ShouldAddWildcard()
+    {
+      using (var db = new Db())
+      {
+        var item = db.GetItem("/sitecore/content/");
+        item.Add("*", new TemplateID(TemplateIDs.Folder));
+      }
+    }
   }
 }


### PR DESCRIPTION
in order to use regex expression same as one from default Sitecore instance. If the setting is missing, there is another regex expression is taken from the 'Sitecore.Configuration.Settings.ItemNameValidation' property.

Addresses #163.