### PR TITLE
Inherit SwitchingAuthenticationProvider from AuthenticationProvider

### DIFF
--- a/src/Sitecore.FakeDb/Security/Authentication/SwitchingAuthenticationProvider.cs
+++ b/src/Sitecore.FakeDb/Security/Authentication/SwitchingAuthenticationProvider.cs
@@ -1,42 +1,86 @@
 ﻿namespace Sitecore.FakeDb.Security.Authentication
 {
-  using System.Collections.Specialized;
   using Sitecore.Common;
+  using Sitecore.Diagnostics;
   using Sitecore.Security.Accounts;
   using Sitecore.Security.Authentication;
 
-  public class SwitchingAuthenticationProvider : Sitecore.Security.Authentication.SwitchingAuthenticationProvider
+  public class SwitchingAuthenticationProvider : AuthenticationProvider
   {
     private readonly User defaultActiveUser = User.FromName(@"default\Anonymous", false);
 
-    private string defaultProvider;
+    private AuthenticationProvider defaultProvider;
 
-    public override void Initialize(string name, NameValueCollection config)
+    public AuthenticationProvider DefaultProvider
     {
-      base.Initialize(name, config);
+      get { return this.defaultProvider; }
+      set
+      {
+        Assert.ArgumentNotNull(value, "value");
+        this.defaultProvider = value;
+      }
+    }
 
-      this.defaultProvider = config["defaultProvider"];
+    private AuthenticationProvider CurrentProvider
+    {
+      get
+      {
+        var switcher = Switcher<AuthenticationProvider>.CurrentValue;
+        if (switcher != null)
+        {
+          return switcher;
+        }
+
+        var provider = this.DefaultProvider;
+        return provider ?? switcher;
+      }
     }
 
     public override User GetActiveUser()
     {
-      var currentProvider = Switcher<AuthenticationProvider>.CurrentValue;
+      return this.CurrentProvider != null ? this.CurrentProvider.GetActiveUser() : this.defaultActiveUser;
+    }
 
-      if (currentProvider == null && !string.IsNullOrEmpty(this.defaultProvider))
+    public override bool Login(User user)
+    {
+      return this.CurrentProvider != null
+        && this.CurrentProvider.Login(user);
+    }
+
+    public override bool Login(string userName, string password, bool persistent)
+    {
+      return this.CurrentProvider != null
+        && this.CurrentProvider.Login(userName, password, persistent);
+    }
+
+    public override bool Login(string userName, bool persistent)
+    {
+      return this.CurrentProvider != null
+        && this.CurrentProvider.Login(userName, persistent);
+    }
+
+    public override void Logout()
+    {
+      if (this.CurrentProvider != null)
       {
-        var provider = AuthenticationManager.Providers[this.defaultProvider];
-        if (provider != null)
-        {
-          return provider.GetActiveUser();
-        }
+        this.CurrentProvider.Logout();
       }
+    }
 
-      if (currentProvider == null)
+    public override void SetActiveUser(string userName)
+    {
+      if (this.CurrentProvider != null)
       {
-        return this.defaultActiveUser;
+        this.CurrentProvider.SetActiveUser(userName);
       }
+    }
 
-      return currentProvider.GetActiveUser();
+    public override void SetActiveUser(User user)
+    {
+      if (this.CurrentProvider != null)
+      {
+        this.CurrentProvider.SetActiveUser(user);
+      }
     }
   }
 }

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -144,8 +144,9 @@
     <authentication defaultProvider="switcher">
       <providers>
         <clear />
-        <add name="switcher" type="Sitecore.FakeDb.Security.Authentication.SwitchingAuthenticationProvider, Sitecore.FakeDb" defaultProvider="fake" />
-        <add name="fake" type="Sitecore.FakeDb.Security.Authentication.FakeAuthenticationProvider, Sitecore.FakeDb" />
+        <add name="switcher" type="Sitecore.FakeDb.Security.Authentication.SwitchingAuthenticationProvider, Sitecore.FakeDb">
+          <DefaultProvider type="Sitecore.FakeDb.Security.Authentication.FakeAuthenticationProvider, Sitecore.FakeDb" />
+        </add>
       </providers>
     </authentication>
     <!-- ROLES -->


### PR DESCRIPTION
because Sitecore's `SwitchingAuthenticationProvider` is marked as obsolete and will be removed in the next major version (#173).