### PR TITLE
Make FakeDb provider switchers obsolete

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-%WINDIR%/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe Build.msbuild /p:Configuration=Release /t:Versions /p:NoWarn=1591
+"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Build.msbuild /p:Configuration=Release /t:Versions /p:NoWarn=1591

--- a/deploy.bat
+++ b/deploy.bat
@@ -3,6 +3,6 @@ setlocal
 :PROMPT
 SET /P AREYOUSURE=Are you sure you want to publish the NuGet packages (Y/[N])?
 IF /I "%AREYOUSURE%" NEQ "Y" GOTO END
-  %WINDIR%/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe Build.msbuild /p:Configuration=Release /t:Deploy /p:NoWarn=1591
+  "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" Build.msbuild /p:Configuration=Release /t:Deploy /p:NoWarn=1591
 :END
 endlocal

--- a/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
+++ b/src/Sitecore.FakeDb/Data/Engines/DataStorage.cs
@@ -181,43 +181,43 @@ namespace Sitecore.FakeDb.Data.Engines
       return this.FakeItems.Remove(itemId);
     }
 
-      public virtual void SetBlobStream(Guid blobId, Stream stream)
+    public virtual void SetBlobStream(Guid blobId, Stream stream)
+    {
+      Assert.ArgumentNotNull(stream, "stream");
+      var currentPostion = stream.Position;
+
+      //it is assumed SC behaviour that when a stream is saved the 
+      //original stream position isn't altered.
+      //A copy of the stream is made so that a subsequent get using GetBlobStream does not
+      //cause a change in original stream position.
+      var storedStream = new MemoryStream();
+      stream.Seek(0, SeekOrigin.Begin);
+      stream.CopyTo(storedStream);
+      storedStream.Seek(0, SeekOrigin.Begin);
+      stream.Seek(currentPostion, SeekOrigin.Begin);
+
+      this.Blobs[blobId] = stream;
+    }
+
+    public virtual Stream GetBlobStream(Guid blobId)
+    {
+      if (!this.Blobs.ContainsKey(blobId))
       {
-          Assert.ArgumentNotNull(stream, "stream");
-          var currentPostion = stream.Position;
-
-            //it is assumed SC behaviour that when a stream is saved the 
-            //original stream position isn't altered.
-            //A copy of the stream is made so that a subsequent get using GetBlobStream does not
-            //cause a change in original stream position.
-          var storedStream = new MemoryStream();
-          stream.Seek(0, SeekOrigin.Begin);
-          stream.CopyTo(storedStream);
-          storedStream.Seek(0, SeekOrigin.Begin);
-          stream.Seek(currentPostion, SeekOrigin.Begin);
-
-          this.Blobs[blobId] = stream;
+        return null;
       }
 
-      public virtual Stream GetBlobStream(Guid blobId)
-      {
-          if (!this.Blobs.ContainsKey(blobId))
-          {
-              return null;
-          }
+      var stream = new MemoryStream();
+      var storedStream = this.Blobs[blobId];
+      // Reset stored stream to position zero to ensure data is read.
+      storedStream.Seek(0, SeekOrigin.Begin);
+      storedStream.CopyTo(stream);
 
-          var stream = new MemoryStream();
-          var storedStream = this.Blobs[blobId];
-          // Reset stored stream to position zero to ensure data is read.
-          storedStream.Seek(0,SeekOrigin.Begin);
-          storedStream.CopyTo(stream);
+      //after copying the stream we must reset the position to 0
+      stream.Seek(0, SeekOrigin.Begin);
+      return stream;
+    }
 
-          //after copying the stream we must reset the position to 0
-          stream.Seek(0, SeekOrigin.Begin);
-          return stream;
-      }
-
-      public FieldList BuildItemFieldList(DbItem fakeItem, ID templateId, Language language, Version version)
+    public FieldList BuildItemFieldList(DbItem fakeItem, ID templateId, Language language, Version version)
     {
       // build a sequence of templates that the item inherits from
       var templates = this.ExpandTemplatesSequence(templateId);
@@ -483,8 +483,10 @@ namespace Sitecore.FakeDb.Data.Engines
       this.FakeItems.Add(TemplateIDs.TemplateSection, new DbTemplate(ItemNames.TemplateSection, TemplateIDs.TemplateSection, TemplateIDs.TemplateSection) { ParentID = ItemIDs.TemplateRoot, FullPath = "/sitecore/templates/template section" });
       this.FakeItems.Add(TemplateIDs.BranchTemplate, new DbItem(ItemNames.Branch, TemplateIDs.BranchTemplate, TemplateIDs.Template) { ParentID = ItemIDs.TemplateRoot, FullPath = "/sitecore/templates/branch" });
 
-      this.AddFakeItem(new DbItem(ItemNames.DefinitionsRoot, ItemIDs.Analytics.MarketingCenterItem, TemplateIDs.Folder) { ParentID = ItemIDs.SystemRoot, FullPath = "/sitecore/system/Marketing Control Panel" });
-      this.AddFakeItem(new DbItem(ItemNames.Profiles, ItemIDs.Analytics.Profiles, TemplateIDs.Folder) { ParentID = ItemIDs.Analytics.MarketingCenterItem, FullPath = "/sitecore/system/Marketing Control Panel/Profiles" });
+      var marketingCenterItem = new ID("{33CFB9CA-F565-4D5B-B88A-7CDFE29A6D71}");
+      this.AddFakeItem(new DbItem(ItemNames.DefinitionsRoot, marketingCenterItem, TemplateIDs.Folder) { ParentID = ItemIDs.SystemRoot, FullPath = "/sitecore/system/Marketing Control Panel" });
+      var profiles = new ID("{12BD7E35-437B-449C-B931-23CFA12C03D8}");
+      this.AddFakeItem(new DbItem(ItemNames.Profiles, profiles, TemplateIDs.Folder) { ParentID = marketingCenterItem, FullPath = "/sitecore/system/Marketing Control Panel/Profiles" });
 
       if (this.Database.Name == "core")
       {

--- a/src/Sitecore.FakeDb/Resources/Media/MediaProviderSwitcher.cs
+++ b/src/Sitecore.FakeDb/Resources/Media/MediaProviderSwitcher.cs
@@ -1,9 +1,16 @@
 ﻿namespace Sitecore.FakeDb.Resources.Media
 {
+  using System;
   using Sitecore.Resources.Media;
 
   public class MediaProviderSwitcher : ThreadLocalProviderSwitcher<MediaProvider>
   {
+    [Obsolete("Starting from Sitecore 8.2, the " +
+          "Sitecore.Resources.Media.MediaProvider " +
+          "class is marked as obsolete and will be removed " +
+          "in the next major release. Please use new abstract " +
+          "type Sitecore.Abstractions.BaseMediaManager " +
+          "from the Sitecore.Kernel assembly.")]
     public MediaProviderSwitcher(MediaProvider innerProvider)
       : base((IThreadLocalProvider<MediaProvider>)MediaManager.Provider, innerProvider)
     {

--- a/src/Sitecore.FakeDb/Security/AccessControl/AuthorizationSwitcher.cs
+++ b/src/Sitecore.FakeDb/Security/AccessControl/AuthorizationSwitcher.cs
@@ -1,9 +1,16 @@
 ﻿namespace Sitecore.FakeDb.Security.AccessControl
 {
+  using System;
   using Sitecore.Security.AccessControl;
 
   public class AuthorizationSwitcher : ThreadLocalProviderSwitcher<AuthorizationProvider>
   {
+    [Obsolete("Starting from Sitecore 8.2, the " +
+              "Sitecore.Security.AccessControl.AuthorizationProvider " +
+              "class is marked as obsolete and will be removed " +
+              "in the next major release. Please use new abstract " +
+              "type Sitecore.Abstractions.BaseAuthorizationManager " +
+              "from the Sitecore.Kernel assembly.")]
     public AuthorizationSwitcher(AuthorizationProvider localProvider)
       : base((IThreadLocalProvider<AuthorizationProvider>)AuthorizationManager.Provider, localProvider)
     {

--- a/src/Sitecore.FakeDb/Security/Accounts/RolesInRolesSwitcher.cs
+++ b/src/Sitecore.FakeDb/Security/Accounts/RolesInRolesSwitcher.cs
@@ -1,7 +1,14 @@
 ﻿namespace Sitecore.FakeDb.Security.Accounts
 {
+  using System;
   using Sitecore.Security.Accounts;
 
+  [Obsolete("Starting from Sitecore 8.2, the " +
+            "Sitecore.Security.Accounts.RolesInRolesProvider " +
+            "class is marked as obsolete and will be removed " +
+            "in the next major release. Please use new abstract " +
+            "type Sitecore.Abstractions.BaseRolesInRolesManager " +
+            "from the Sitecore.Kernel assembly.")]
   public class RolesInRolesSwitcher : ThreadLocalProviderSwitcher<RolesInRolesProvider>
   {
     public RolesInRolesSwitcher(RolesInRolesProvider localProvider)

--- a/test/Sitecore.FakeDb.Tests/Configuration/ConfigurationTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Configuration/ConfigurationTest.cs
@@ -49,7 +49,9 @@
     public void ShouldGetFakeStandardValuesProvider()
     {
       // assert
+#pragma warning disable 618
       StandardValuesManager.Provider.Should().BeOfType<FakeStandardValuesProvider>();
+#pragma warning restore 618
     }
 
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/LayoutFieldTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/LayoutFieldTest.cs
@@ -76,7 +76,9 @@ namespace Sitecore.FakeDb.Tests.Data.Fields
       {
         Item item = db.GetItem("/sitecore/content/page");
 
+#pragma warning disable 618
         Assert.Equal(templateLayout, StandardValuesManager.Provider.GetStandardValue(item.Fields[FieldIDs.LayoutField]));
+#pragma warning restore 618
 
         Assert.Equal(templateLayout, LayoutField.GetFieldValue(item.Fields[FieldIDs.LayoutField]));
         // standard values

--- a/test/Sitecore.FakeDb.Tests/GettingStarted.cs
+++ b/test/Sitecore.FakeDb.Tests/GettingStarted.cs
@@ -259,7 +259,9 @@
           .Returns(new Sitecore.FakeDb.Security.AccessControl.DenyAccessResult());
 
         // switch the authorization provider
+#pragma warning disable 618
         using (new Sitecore.FakeDb.Security.AccessControl.AuthorizationSwitcher(provider))
+#pragma warning restore 618
         {
           // check the user cannot read the item
           bool canRead =
@@ -303,7 +305,9 @@
       provider.IsUserInRole(user, role, true).Returns(true);
 
       // switch the roles-in-roles provider so the mocked version is used
+#pragma warning disable 618
       using (new Sitecore.FakeDb.Security.Accounts.RolesInRolesSwitcher(provider))
+#pragma warning restore 618
       {
         Xunit.Assert.True(user.IsInRole(role));
       }
@@ -343,7 +347,9 @@
         var provider =
           Substitute.For<Sitecore.Security.AccessControl.AuthorizationProvider>();
 
+#pragma warning disable 618
         using (new Sitecore.FakeDb.Security.AccessControl.AuthorizationSwitcher(provider))
+#pragma warning restore 618
         {
           // call your business logic that changes the item security, e.g. denies Read
           // for Editors
@@ -745,7 +751,7 @@
       {
         Sitecore.Data.Items.Item mediaItem = db.GetItem(mediaItemId);
 
-        // create media provider mock and configure behaviour
+        // create media provider mock and configure behavior
         Sitecore.Resources.Media.MediaProvider mediaProvider =
           NSubstitute.Substitute.For<Sitecore.Resources.Media.MediaProvider>();
 
@@ -754,7 +760,9 @@
           .Returns(MyImageUrl);
 
         // substitute the original provider with the mocked one
+#pragma warning disable 618
         using (new Sitecore.FakeDb.Resources.Media.MediaProviderSwitcher(mediaProvider))
+#pragma warning restore 618
         {
           string mediaUrl = Sitecore.Resources.Media.MediaManager.GetMediaUrl(mediaItem);
           Xunit.Assert.Equal(MyImageUrl, mediaUrl);

--- a/test/Sitecore.FakeDb.Tests/Resources/Media/MediaProviderSwitcherTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Resources/Media/MediaProviderSwitcherTest.cs
@@ -1,11 +1,13 @@
 ﻿namespace Sitecore.FakeDb.Tests.Resources.Media
 {
+  using System;
   using FluentAssertions;
   using NSubstitute;
   using Sitecore.FakeDb.Resources.Media;
   using Sitecore.Resources.Media;
   using Xunit;
 
+  [Obsolete]
   public class MediaProviderSwitcherTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Security/AccessControl/AuthorizationManagerTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/AccessControl/AuthorizationManagerTest.cs
@@ -11,7 +11,9 @@
     public void ShouldResolveDefaultAuthorizationProvider()
     {
       // act & assert
+#pragma warning disable 618
       AuthorizationManager.Provider.Should().BeOfType<FakeAuthorizationProvider>();
+#pragma warning restore 618
     }
   }
 }

--- a/test/Sitecore.FakeDb.Tests/Security/AccessControl/AuthorizationSwitcherTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/AccessControl/AuthorizationSwitcherTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace Sitecore.FakeDb.Tests.Security.AccessControl
 {
+  using System;
   using FluentAssertions;
   using NSubstitute;
   using Sitecore.FakeDb.Security.AccessControl;
@@ -7,6 +8,7 @@
   using Sitecore.Security.Accounts;
   using Xunit;
 
+  [Obsolete]
   [Trait("Category", "RequireLicense")]
   public class AuthorizationSwitcherTest
   {

--- a/test/Sitecore.FakeDb.Tests/Security/Accounts/RolesInRolesSwitcherTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/Accounts/RolesInRolesSwitcherTest.cs
@@ -1,11 +1,13 @@
 ﻿namespace Sitecore.FakeDb.Tests.Security.Accounts
 {
+  using System;
   using FluentAssertions;
   using NSubstitute;
   using Sitecore.FakeDb.Security.Accounts;
   using Sitecore.Security.Accounts;
   using Xunit;
 
+  [Obsolete]
   public class RolesInRolesSwitcherTest
   {
     [Fact]

--- a/test/Sitecore.FakeDb.Tests/Security/Accounts/UserTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/Accounts/UserTest.cs
@@ -86,7 +86,9 @@
       var rolesProvider = Substitute.For<RolesInRolesProvider>();
       rolesProvider.IsUserInRole(user, role, true).Returns(isInRole);
 
+#pragma warning disable 618
       using (new RolesInRolesSwitcher(rolesProvider))
+#pragma warning restore 618
       {
         // act & assert
         user.IsInRole(@"sitecore\Editor").Should().Be(isInRole);

--- a/test/Sitecore.FakeDb.Tests/Security/Authentication/AuthenticationSwitcherTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/Authentication/AuthenticationSwitcherTest.cs
@@ -24,7 +24,9 @@
       {
         using (new AuthenticationSwitcher(provider))
         {
+#pragma warning disable 618
           AuthenticationManager.Provider.GetActiveUser().Should().BeSameAs(user);
+#pragma warning restore 618
 
           Thread.Sleep(100);
         }
@@ -33,7 +35,9 @@
       // assert
       var t2 = Task.Factory.StartNew(() =>
       {
+#pragma warning disable 618
         AuthenticationManager.Provider.GetActiveUser().Should().NotBeSameAs(user);
+#pragma warning restore 618
       });
 
       t1.Wait();


### PR DESCRIPTION
since the providers became obsolete in Sitecore 8.2 and will be removed in the next major release (#175).