### PR TITLE
Adding a meaningful error message if FakeDb.Serialization encounters a duplicated Item ID

### DIFF
--- a/src/Sitecore.FakeDb.Serialization/DuplicateIdException.cs
+++ b/src/Sitecore.FakeDb.Serialization/DuplicateIdException.cs
@@ -1,0 +1,25 @@
+﻿using Sitecore.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Sitecore.FakeDb.Serialization
+{
+
+  /// <summary>
+  /// Exception thrown if the deserialization logic encounters a duplicated content item ID.
+  /// Ensures that the user gets a meaningful error message to help them debug their serialized content.
+  /// </summary>
+  public class DuplicateIdException : ArgumentException
+  {
+    public DuplicateIdException(ID id, string firstFile, string secondFile)
+      : base(string.Format(
+        "FakeDb.Serialization is unable to process this content tree.\n\nThe item id {0} defined by item file being processed \"{1}\" has already been already used by the item in \"{2}\"", 
+        id, firstFile, secondFile))
+    {
+    }
+  }
+
+}

--- a/src/Sitecore.FakeDb.Serialization/SerializedIdToPathDictionary.cs
+++ b/src/Sitecore.FakeDb.Serialization/SerializedIdToPathDictionary.cs
@@ -65,6 +65,10 @@
               }
 
               var itemId = ID.Parse(itemIdStr);
+              if (pathSet.Paths.ContainsKey(itemId))
+              {
+                throw new DuplicateIdException(itemId, file, pathSet.Paths[itemId]);
+              }
               pathSet.Paths.Add(itemId, file);
               if (itemId == id)
               {

--- a/src/Sitecore.FakeDb.Serialization/Sitecore.FakeDb.Serialization.csproj
+++ b/src/Sitecore.FakeDb.Serialization/Sitecore.FakeDb.Serialization.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Deserializer.cs" />
     <Compile Include="DsDbItem.cs" />
     <Compile Include="DsDbTemplate.cs" />
+    <Compile Include="DuplicateIdException.cs" />
     <Compile Include="Pipelines\CopyParentId.cs" />
     <Compile Include="Pipelines\CopySharedFields.cs" />
     <Compile Include="Pipelines\CopyVersionedFields.cs" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/App.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/App.config
@@ -6,6 +6,7 @@
       <folder name="core" value="..\..\Data\CoreSerialization\core\" />
       <folder name="master" value="..\..\Data\Serialization\master\" />
       <folder name="custom" value="..\..\Data\CustomSerialization\master\" />
+      <folder name="incorrect" value="..\..\Data\IncorrectSerialization\master\" />
     </szfolders>
     <pipelines>
       <loadDsDbItem>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Data/IncorrectSerialization/master/sitecore/content/ItemOne.item
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Data/IncorrectSerialization/master/sitecore/content/ItemOne.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {108266C2-304B-4AD3-9813-2BE1B88609FF}
+database: master
+path: /sitecore/content/Item only available in custom serialization folder
+parent: {0DE95AE4-41AB-4D01-9EB0-67441B7C2450}
+name: Item only available in custom serialization folder
+master: {00000000-0000-0000-0000-000000000000}
+template: {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+templatekey: Folder
+
+----version----
+language: en
+version: 1
+revision: 9a93e109-ce03-4f04-95bb-15d6dd3041f3
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20140928T183147Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+9a93e109-ce03-4f04-95bb-15d6dd3041f3
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20140928T183147:635475259073629721Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/test/Sitecore.FakeDb.Serialization.Tests/Data/IncorrectSerialization/master/sitecore/content/ItemTwo.item
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Data/IncorrectSerialization/master/sitecore/content/ItemTwo.item
@@ -1,0 +1,51 @@
+----item----
+version: 1
+id: {108266C2-304B-4AD3-9813-2BE1B88609FF}
+database: master
+path: /sitecore/content/Item only available in custom serialization folder
+parent: {0DE95AE4-41AB-4D01-9EB0-67441B7C2450}
+name: Item only available in custom serialization folder
+master: {00000000-0000-0000-0000-000000000000}
+template: {A87A00B1-E6DB-45AB-8B54-636FEC3B5523}
+templatekey: Folder
+
+----version----
+language: en
+version: 1
+revision: 9a93e109-ce03-4f04-95bb-15d6dd3041f3
+
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 16
+
+20140928T183147Z
+----field----
+field: {5DD74568-4D4B-44C1-B513-0AF5F4CDA34F}
+name: __Created by
+key: __created by
+content-length: 14
+
+sitecore\admin
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+9a93e109-ce03-4f04-95bb-15d6dd3041f3
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 35
+
+20140928T183147:635475259073629721Z
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/test/Sitecore.FakeDb.Serialization.Tests/SerializedIdToPathResolverTest.cs
+++ b/test/Sitecore.FakeDb.Serialization.Tests/SerializedIdToPathResolverTest.cs
@@ -16,5 +16,13 @@
       File.Exists(filePath).Should().BeTrue();
       Path.GetFileNameWithoutExtension(filePath).ShouldBeEquivalentTo("Item only available in custom serialization folder");
     }
+
+    [Fact]
+    public void DuplicatedID_Throws_MeaningfulException()
+    {
+      Assert.Throws<DuplicateIdException>(() => {
+        ID.Parse("{108266C2-304B-4AD3-9813-2BE1B88609FF}").FindFilePath("incorrect");
+      });
+    }
   }
 }

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -134,6 +134,7 @@
   <ItemGroup>
     <Folder Include="Data\CoreSerialization\" />
     <Folder Include="Data\CustomSerialization\" />
+    <Folder Include="Data\IncorrectSerialization\" />
     <Folder Include="Data\LargeSetSerialization\" />
     <Folder Include="Data\Serialization\" />
   </ItemGroup>


### PR DESCRIPTION
I tried to use the Serialization extension to FakeDb against some pre-existing serialised content on an old development machine, and I came across a situation where you got an unhelpful error message because of some bad data. So I've tried to improve the error to help any future developers who hit the same issue...

The situation was that at some point an item had been serialised, then renamed and serialised again. The serialisation folders hadn't been tidied up - so there were two files with different names but containing the same Item ID sitting on disk.

When I created a DsDbItem() that tried to read this tree (and hence encountered the duplicate ID) it raised an error - `System.ArgumentException: An item with the same key has already been added`. While that error is factually correct, it doesn't provide any help in tracking down what key was duplicated - and if you have a lot of serialised data that can be a bit of a pain. It's also not very helpful to new users of your tool - who might not immediately grasp why that error could be raised.

Hence I've added a new `DuplicateIdException` class, which has a more helpful message listing the ID in question as well as the two serialised files that are conflicting. When the `SerializedIdToPathResolver.FindFilePath()` extension method spots a duplicate, it raises this new exception instead of the default exception from the underlying `Dictionary` object. I've added some test data that causes the error, as well as a simple unit test which checks that deserialising an item with a duplicate ID raises the right exception.

Hopefully you think that's a helpful change. If there's anything I've done here that you don't like, then let me know - I'm happy to make edits if you want me to.