### PR TITLE
Added references to Sitecore pipelines necessary for testing updates to layout fields with Sitecore 9

### DIFF
--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -31,6 +31,10 @@
         <processor type="Sitecore.Pipelines.GetFieldValue.GetStandardValue, Sitecore.Kernel" />
         <processor type="Sitecore.Pipelines.GetFieldValue.GetDefaultValue, Sitecore.Kernel" />
       </getFieldValue>
+      <getLayoutSourceFields>
+        <processor type="Sitecore.Pipelines.GetLayoutSourceFields.GetFinalLayoutField, Sitecore.Kernel" />
+        <processor type="Sitecore.Pipelines.GetLayoutSourceFields.GetLayoutField, Sitecore.Kernel" />
+      </getLayoutSourceFields>
       <!-- FakeDb -->
       <initFakeDb>
         <processor type="Sitecore.FakeDb.Pipelines.InitFakeDb.InitGlobals, Sitecore.FakeDb" />


### PR DESCRIPTION
Am currently working on a project just upgraded to Sitecore 9, and found a few FakeDB related tests failing.  The common issue was tests being made on layout fields.

From some decompiling I could see that the `Sitecore.Data.Fields.LayoutField.GetFieldValue()` method had changed, to require a couple of methods referenced from pipeline components that it wasn't using in version 8.2.  Adding these two to the configuration as per this PR, recompiling and then referenced the built Sitecore.FakeDb.dll resolved this.