### PR TITLE
[V3] Upgrade to Sitecore 9.3

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
-    <package id="xunit.runner.msbuild" version="2.0.0" />
+    <package id="xunit.runner.msbuild" version="2.4.1" />
 </packages>

--- a/build.config
+++ b/build.config
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <NuGet>.nuget\nuget.exe</NuGet>
         <OutputDirectory>output</OutputDirectory>
-        <XUnitPath>packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS</XUnitPath>
+        <XUnitPath>packages\xunit.runner.msbuild.2.4.1\build\net452</XUnitPath>
         <ProjectToBuild>Sitecore.FakeDb.sln</ProjectToBuild>
         <FakeDbDir>src\Sitecore.FakeDb</FakeDbDir>
         <FakeDbTestsDir>test\Sitecore.FakeDb.Tests</FakeDbTestsDir>

--- a/build.msbuild
+++ b/build.msbuild
@@ -19,10 +19,6 @@
     <CleanUp Include="test\**\Sitecore.FakeDb.Tests.config" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <PatchDatabase>false</PatchDatabase>
-  </PropertyGroup>
-
   <Target Name="Clean">
     <MSBuild Projects="$(ProjectToBuild)" Targets="Clean" />
     <RemoveDir Directories="$(OutputDirectory)" />
@@ -68,14 +64,6 @@
 
   <Target Name="Tests" DependsOnTargets="Compile">
     <Message Text="=== RUNNING TESTS FOR $(Version) ===" Importance="high" />
-
-    <!-- Patch database type for SC82 -->
-    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="$(FakeDbTestsDir)\App_Config\Include" Condition="$(PatchDatabase)" />
-    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="$(AutoFixtureTestsDir)\App_Config\Include" Condition="$(PatchDatabase)" />
-    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="$(NSubstituteTestsDir)\App_Config\Include" Condition="$(PatchDatabase)" />
-    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="$(SerializationTestsDir)\App_Config\Include" Condition="$(PatchDatabase)" />
-    <Copy SourceFiles="lib\SC820\Sitecore.FakeDb.Tests.config" DestinationFolder="test\Sitecore.FakeDb.NUnitLite.Tests\App_Config\Include" Condition="$(PatchDatabase)" />
-
     <xunit Assemblies="@(TestAssemblies)" ParallelizeTestCollections="false" Xml="TestResult_$(Version).xml" />
     <Exec Command="Sitecore.FakeDb.NUnitLite.Tests.exe" WorkingDirectory="test\Sitecore.FakeDb.NUnitLite.Tests\bin\Release" />
   </Target>

--- a/build.msbuild
+++ b/build.msbuild
@@ -8,7 +8,6 @@
   <ItemGroup>
     <Versions Include="$(SupportedSitecoreVersions)" />
     <References Include="packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll" />
-    <References Include="packages\Sitecore.Abstractions.$(Version)\lib\$(TargetFrameworkFolder)\Sitecore.Abstractions.dll" Condition="'$(Version)' != '7.2.160123'" />
     <References Include="packages\Sitecore.Buckets.$(Version)\lib\$(TargetFrameworkFolder)\Sitecore.Buckets.dll" />
     <References Include="packages\Sitecore.ContentSearch.$(Version)\lib\$(TargetFrameworkFolder)\Sitecore.ContentSearch.dll" />
     <References Include="packages\Sitecore.ContentSearch.Data.$(Version)\lib\$(TargetFrameworkFolder)\Sitecore.ContentSearch.Data.dll" />
@@ -32,7 +31,6 @@
   <Target Name="Compile" DependsOnTargets="Clean">
     <Exec Command="$(NuGet) restore" />
     <Exec Command="$(NuGet) install Lucene.Net -Version 3.0.3 -OutputDirectory packages" />
-    <Exec Command="$(NuGet) install Sitecore.Abstractions -Version $(Version) -OutputDirectory packages" Condition="'$(Version)' != '7.2.160123'" />
     <Exec Command="$(NuGet) install Sitecore.Buckets -Version $(Version) -OutputDirectory packages" />
     <Exec Command="$(NuGet) install Sitecore.ContentSearch -Version $(Version) -OutputDirectory packages" />
     <Exec Command="$(NuGet) install Sitecore.ContentSearch.Linq -Version $(Version) -OutputDirectory packages" />

--- a/build.msbuild
+++ b/build.msbuild
@@ -3,7 +3,7 @@
   <Import Project="Build.config" />
   <Import Project="version.props" />
 
-  <UsingTask TaskName="xunit" AssemblyFile="$(XUnitPath)\xunit.runner.msbuild.dll" />
+  <UsingTask TaskName="xunit" AssemblyFile="$(XUnitPath)\xunit.runner.msbuild.net452.dll" />
 
   <ItemGroup>
     <Versions Include="$(SupportedSitecoreVersions)" />

--- a/lib/SC820/Sitecore.FakeDb.Tests.config
+++ b/lib/SC820/Sitecore.FakeDb.Tests.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-  <sitecore>
-    <sc.variable name="databaseType" value="Sitecore.Data.DefaultDatabase, Sitecore.Kernel" />
-  </sitecore>
-</configuration>

--- a/src/Sitecore.FakeDb.NSubstitute/Sitecore.FakeDb.NSubstitute.csproj
+++ b/src/Sitecore.FakeDb.NSubstitute/Sitecore.FakeDb.NSubstitute.csproj
@@ -38,8 +38,8 @@
       <HintPath>..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=4.2.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.4.2.1\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\lib\Sitecore.Kernel.dll</HintPath>

--- a/src/Sitecore.FakeDb.NSubstitute/packages.config
+++ b/src/Sitecore.FakeDb.NSubstitute/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.2.0" targetFramework="net452" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
+  <package id="NSubstitute" version="4.2.1" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />
 </packages>

--- a/src/Sitecore.FakeDb/Configuration/DbConfiguration.cs
+++ b/src/Sitecore.FakeDb/Configuration/DbConfiguration.cs
@@ -1,19 +1,21 @@
-﻿namespace Sitecore.FakeDb.Configuration
+namespace Sitecore.FakeDb.Configuration
 {
+    using System;
     using System.Xml;
 
-    public class DbConfiguration
+    public class DbConfiguration : IDisposable
     {
-        private readonly Settings settings;
-
         public DbConfiguration(XmlDocument config)
         {
-            this.settings = new Settings(config);
+            Settings = new Settings(config);
         }
 
-        public Settings Settings
+        public Settings Settings { get; }
+
+        public void Dispose()
         {
-            get { return this.settings; }
+            Settings?.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Sitecore.FakeDb/Configuration/EventManagerStub.cs
+++ b/src/Sitecore.FakeDb/Configuration/EventManagerStub.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Configuration
+namespace Sitecore.FakeDb.Configuration
 {
     using System;
     using Sitecore.Abstractions;
@@ -8,27 +8,7 @@
     {
         public override bool Enabled => false;
 
-        [Obsolete]
-        public override void QueueEvent<TEvent>(TEvent @event)
-        {
-        }
-
-        [Obsolete]
-        public override void QueueEvent<TEvent>(TEvent @event, bool addToGlobalQueue, bool addToLocalQueue)
-        {
-        }
-
         public override void RaiseEvent<TEvent>(TEvent @event)
-        {
-        }
-
-        [Obsolete]
-        public override void RaiseQueuedEvents()
-        {
-        }
-
-        [Obsolete]
-        public override void RemoveQueuedEvents(EventQueueQuery query)
         {
         }
 

--- a/src/Sitecore.FakeDb/Configuration/Settings.cs
+++ b/src/Sitecore.FakeDb/Configuration/Settings.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Configuration
+namespace Sitecore.FakeDb.Configuration
 {
     using System.Xml;
     using Sitecore.Diagnostics;
@@ -65,10 +65,6 @@
                     var setting = this.CreateSettingNode(name, value);
                     settingsNode.AppendChild(setting);
                 }
-
-#pragma warning disable 618
-                Sitecore.Configuration.Settings.Reset();
-#pragma warning restore 618
             }
         }
 

--- a/src/Sitecore.FakeDb/Configuration/Settings.cs
+++ b/src/Sitecore.FakeDb/Configuration/Settings.cs
@@ -1,11 +1,15 @@
 namespace Sitecore.FakeDb.Configuration
 {
     using System.Xml;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using Sitecore.Configuration;
     using Sitecore.Diagnostics;
     using Sitecore.StringExtensions;
     using Sitecore.Xml;
 
-    public class Settings
+    public class Settings : IDisposable
     {
         private const string AutoTranslateSetting = "FakeDb.AutoTranslate";
 
@@ -13,14 +17,14 @@ namespace Sitecore.FakeDb.Configuration
 
         private const string AutoTranslateSuffixSetting = "FakeDb.AutoTranslateSuffix";
 
-        private readonly XmlDocument section;
+        private readonly ICollection<SettingsSwitcher> switchers = new Collection<SettingsSwitcher>();
 
         public Settings(XmlDocument section)
         {
-            this.section = section;
+            ConfigSection = section;
         }
 
-        protected internal XmlDocument ConfigSection => this.section;
+        protected internal XmlDocument ConfigSection { get; }
 
         public bool AutoTranslate
         {
@@ -61,16 +65,18 @@ namespace Sitecore.FakeDb.Configuration
                 }
                 else
                 {
-                    var settingsNode = XmlUtil.EnsurePath("/sitecore/settings", this.section);
+                    var settingsNode = XmlUtil.EnsurePath("/sitecore/settings", this.ConfigSection);
                     var setting = this.CreateSettingNode(name, value);
                     settingsNode.AppendChild(setting);
                 }
+
+                switchers.Add(new SettingsSwitcher(name, value));
             }
         }
 
         protected virtual XmlElement CreateSettingNode(string name, string value)
         {
-            var doc = this.section;
+            var doc = this.ConfigSection;
             var setting = doc.CreateElement("setting");
 
             this.AddSettingAttribute("name", name, doc, setting);
@@ -89,7 +95,16 @@ namespace Sitecore.FakeDb.Configuration
 
         protected virtual XmlNode SelectSettingNode(string name)
         {
-            return this.section.SelectSingleNode("/sitecore/settings/setting[@name='{0}']".FormatWith(name));
+            return this.ConfigSection.SelectSingleNode("/sitecore/settings/setting[@name='{0}']".FormatWith(name));
+        }
+
+        public void Dispose()
+        {
+            foreach (var switcher in switchers)
+            {
+                switcher.Dispose();
+            }
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Sitecore.FakeDb/ContentSearch/SwitchingSearchProvider.cs
+++ b/src/Sitecore.FakeDb/ContentSearch/SwitchingSearchProvider.cs
@@ -1,6 +1,5 @@
-﻿namespace Sitecore.FakeDb.ContentSearch
+namespace Sitecore.FakeDb.ContentSearch
 {
-    using System;
     using Sitecore.Abstractions;
     using Sitecore.Common;
     using Sitecore.ContentSearch;
@@ -13,10 +12,7 @@
             return currentProvider != null ? currentProvider.GetContextIndexName(indexable) : null;
         }
 
-        [Obsolete("ICorePipeline is obsolete in Sitecore")]
-#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
-        public override string GetContextIndexName(IIndexable indexable, ICorePipeline pipeline)
-#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
+        public override string GetContextIndexName(IIndexable indexable, BaseCorePipelineManager pipeline)
         {
             var currentProvider = Switcher<SearchProvider>.CurrentValue;
             return currentProvider?.GetContextIndexName(indexable, pipeline);

--- a/src/Sitecore.FakeDb/Data/DataProviders/FakeDataProvider.cs
+++ b/src/Sitecore.FakeDb/Data/DataProviders/FakeDataProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Data.DataProviders
+namespace Sitecore.FakeDb.Data.DataProviders
 {
     using System;
     using System.Collections.Generic;
@@ -123,6 +123,7 @@
             return this.DataStorage.RemoveFakeItem(item.ID);
         }
 
+        [Obsolete("GetBlobStream method is obsolete. Use BlobStorage.GetBlob method instead.")]
         public override Stream GetBlobStream(Guid blobId, CallContext context)
         {
             return this.DataStorage.GetBlobStream(blobId);
@@ -374,54 +375,12 @@
             return items != null ? IDList.Build(items.Select(i => i.ID).ToArray()) : new IDList();
         }
 
+        [Obsolete("SetBlobStream method is obsolete. Use BlobStorage.SetBlob method instead.")]
         public override bool SetBlobStream(Stream stream, Guid blobId, CallContext context)
         {
             this.DataStorage.SetBlobStream(blobId, stream);
 
             return true;
-        }
-
-        /// <summary>
-        /// Sets the property.
-        /// </summary>
-        /// <param name="name">The property name.</param>
-        /// <param name="value">The property value.</param>
-        /// <param name="context">The context. Ignored.</param>
-        /// <returns>Always True.</returns>
-        [Obsolete]
-        public override bool SetProperty(string name, string value, CallContext context)
-        {
-            Assert.ArgumentNotNull(name, "name");
-            var currentProp = this.properties.Value;
-            if (currentProp == null)
-            {
-                this.properties.Value = new Dictionary<string, string> { { name, value } };
-            }
-            else
-            {
-                this.properties.Value[name] = value;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Get the property.
-        /// </summary>
-        /// <param name="name">The property name.</param>
-        /// <param name="context">The context. Ignored.</param>
-        /// <returns>The property value if exists. Otherwise null.</returns>
-        [Obsolete]
-        public override string GetProperty(string name, CallContext context)
-        {
-            Assert.ArgumentNotNull(name, "name");
-            var currentProp = this.properties.Value;
-            if (currentProp == null)
-            {
-                return null;
-            }
-
-            return currentProp.ContainsKey(name) ? currentProp[name] : null;
         }
 
         protected virtual Template BuildTemplate(DbTemplate ft, TemplateCollection templates)

--- a/src/Sitecore.FakeDb/Data/FakeStandardValuesProvider.cs
+++ b/src/Sitecore.FakeDb/Data/FakeStandardValuesProvider.cs
@@ -1,3 +1,5 @@
+using Sitecore.Abstractions;
+
 namespace Sitecore.FakeDb.Data
 {
     using Sitecore.Data;
@@ -8,10 +10,16 @@ namespace Sitecore.FakeDb.Data
     using Sitecore.FakeDb.Data.Engines;
     using Sitecore.StringExtensions;
 
-#pragma warning disable 618
     public class FakeStandardValuesProvider : StandardValuesProvider
-#pragma warning restore 618
     {
+        public FakeStandardValuesProvider(
+            BaseItemManager itemManager,
+            BaseTemplateManager templateManager,
+            BaseFactory factory)
+            : base(itemManager, templateManager, factory)
+        {
+        }
+
         public virtual DataStorage DataStorage(Database database)
         {
             Assert.IsNotNull(database, "database");

--- a/src/Sitecore.FakeDb/Db.cs
+++ b/src/Sitecore.FakeDb/Db.cs
@@ -3,7 +3,6 @@ namespace Sitecore.FakeDb
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Xml;
     using Sitecore.Common;
@@ -261,6 +260,7 @@ namespace Sitecore.FakeDb
 
             this.dataStorageSwitcher.Dispose();
             this.databaseSwitcher.Dispose();
+            this.configuration?.Dispose();
 
             foreach (var languageSwitcher in this.databaseLanguages)
             {

--- a/src/Sitecore.FakeDb/Links/SwitchingLinkProvider.cs
+++ b/src/Sitecore.FakeDb/Links/SwitchingLinkProvider.cs
@@ -1,9 +1,12 @@
 namespace Sitecore.FakeDb.Links
 {
     using System;
+    using System.Collections.Specialized;
+    using System.Web;
     using Sitecore.Common;
     using Sitecore.Data.Items;
     using Sitecore.Links;
+    using Sitecore.Links.UrlBuilders;
     using Sitecore.Web;
 
     [Obsolete("This class is not supported starting from Sitecore 8.2.0. " +
@@ -105,10 +108,29 @@ namespace Sitecore.FakeDb.Links
             return current != null ? current.GetDefaultUrlOptions() : base.GetDefaultUrlOptions();
         }
 
+        public override void Initialize(string name, NameValueCollection config)
+        {
+            var current = this.CurrentProvider;
+            if (current != null)
+            {
+                current.Initialize(name, config);
+            }
+            else
+            {
+                base.Initialize(name, config);
+            }
+        }
+
         public override string GetDynamicUrl(Item item, LinkUrlOptions options)
         {
             var current = this.CurrentProvider;
             return current != null ? current.GetDynamicUrl(item, options) : base.GetDynamicUrl(item, options);
+        }
+
+        public override string GetItemUrl(Item item, ItemUrlBuilderOptions options)
+        {
+            var current = this.CurrentProvider;
+            return current != null ? current.GetItemUrl(item, options) : base.GetItemUrl(item, options);
         }
 
         [Obsolete("Please use GetItemUrl(Item, ItemUrlBuilderOptions) instead.")]
@@ -128,6 +150,12 @@ namespace Sitecore.FakeDb.Links
         {
             var current = this.CurrentProvider;
             return current != null ? current.ParseDynamicLink(linkText) : base.ParseDynamicLink(linkText);
+        }
+
+        public override RequestUrl ParseRequestUrl(HttpRequestBase request)
+        {
+            var current = this.CurrentProvider;
+            return current != null ? current.ParseRequestUrl(request) : base.ParseRequestUrl(request);
         }
 
         [Obsolete("Please use IItemBasedSiteResolver instead.")]

--- a/src/Sitecore.FakeDb/Links/SwitchingLinkProvider.cs
+++ b/src/Sitecore.FakeDb/Links/SwitchingLinkProvider.cs
@@ -1,7 +1,6 @@
 namespace Sitecore.FakeDb.Links
 {
     using System;
-    using System.Web;
     using Sitecore.Common;
     using Sitecore.Data.Items;
     using Sitecore.Links;
@@ -99,6 +98,7 @@ namespace Sitecore.FakeDb.Links
             }
         }
 
+        [Obsolete("Please use GetDefaultUrlBuilderOptions() instead.")]
         public override UrlOptions GetDefaultUrlOptions()
         {
             var current = this.CurrentProvider;
@@ -111,6 +111,7 @@ namespace Sitecore.FakeDb.Links
             return current != null ? current.GetDynamicUrl(item, options) : base.GetDynamicUrl(item, options);
         }
 
+        [Obsolete("Please use GetItemUrl(Item, ItemUrlBuilderOptions) instead.")]
         public override string GetItemUrl(Item item, UrlOptions options)
         {
             var current = this.CurrentProvider;
@@ -129,12 +130,7 @@ namespace Sitecore.FakeDb.Links
             return current != null ? current.ParseDynamicLink(linkText) : base.ParseDynamicLink(linkText);
         }
 
-        public override RequestUrl ParseRequestUrl(HttpRequest request)
-        {
-            var current = this.CurrentProvider;
-            return current != null ? current.ParseRequestUrl(request) : base.ParseRequestUrl(request);
-        }
-
+        [Obsolete("Please use IItemBasedSiteResolver instead.")]
         public override SiteInfo ResolveTargetSite(Item item)
         {
             var current = this.CurrentProvider;

--- a/src/Sitecore.FakeDb/Pipelines/ReleaseFakeDb/ResetSettings.cs
+++ b/src/Sitecore.FakeDb/Pipelines/ReleaseFakeDb/ResetSettings.cs
@@ -1,15 +1,11 @@
-﻿namespace Sitecore.FakeDb.Pipelines.ReleaseFakeDb
+namespace Sitecore.FakeDb.Pipelines.ReleaseFakeDb
 {
-    using Sitecore.Configuration;
     using Sitecore.Pipelines;
 
     public class ResetSettings
     {
         public void Process(PipelineArgs args)
         {
-#pragma warning disable 618
-            Settings.Reset();
-#pragma warning restore 618
         }
     }
 }

--- a/src/Sitecore.FakeDb/Resources/Media/FakeMediaProvider.cs
+++ b/src/Sitecore.FakeDb/Resources/Media/FakeMediaProvider.cs
@@ -1,9 +1,10 @@
-﻿namespace Sitecore.FakeDb.Resources.Media
+namespace Sitecore.FakeDb.Resources.Media
 {
     using System;
     using System.Threading;
     using System.Web;
     using Sitecore.Data.Items;
+    using Sitecore.Links.UrlBuilders;
     using Sitecore.Resources.Media;
 
     public class FakeMediaProvider : MediaProvider, IThreadLocalProvider<MediaProvider>
@@ -112,7 +113,7 @@
             return this.IsLocalProviderSet() ? this.localProvider.Value.GetMediaUrl(item) : null;
         }
 
-        public override string GetMediaUrl(MediaItem item, MediaUrlOptions options)
+        public override string GetMediaUrl(MediaItem item, MediaUrlBuilderOptions options)
         {
             return this.IsLocalProviderSet() ? this.localProvider.Value.GetMediaUrl(item, options) : null;
         }

--- a/src/Sitecore.FakeDb/Security/AccessControl/FakeAuthorizationProvider.cs
+++ b/src/Sitecore.FakeDb/Security/AccessControl/FakeAuthorizationProvider.cs
@@ -20,11 +20,6 @@ namespace Sitecore.FakeDb.Security.AccessControl
             get { return this.localProvider; }
         }
 
-        public FakeAuthorizationProvider()
-            : this(new ItemAuthorizationHelper(null, null, null))
-        {
-        }
-
         public FakeAuthorizationProvider(ItemAuthorizationHelper itemHelper)
         {
             Assert.ArgumentNotNull(itemHelper, "itemHelper");

--- a/src/Sitecore.FakeDb/Security/AccessControl/FakeAuthorizationProvider.cs
+++ b/src/Sitecore.FakeDb/Security/AccessControl/FakeAuthorizationProvider.cs
@@ -21,9 +21,7 @@ namespace Sitecore.FakeDb.Security.AccessControl
         }
 
         public FakeAuthorizationProvider()
-#pragma warning disable 618
-            : this(new ItemAuthorizationHelper())
-#pragma warning restore 618
+            : this(new ItemAuthorizationHelper(null, null, null))
         {
         }
 

--- a/src/Sitecore.FakeDb/Sitecore.FakeDb.csproj
+++ b/src/Sitecore.FakeDb/Sitecore.FakeDb.csproj
@@ -42,9 +42,6 @@
       <HintPath>..\..\lib\Lucene.Net.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Sitecore.Abstractions">
-      <HintPath>..\..\lib\Sitecore.Abstractions.dll</HintPath>
-    </Reference>
     <Reference Include="Sitecore.ContentSearch">
       <HintPath>..\..\lib\Sitecore.ContentSearch.dll</HintPath>
     </Reference>

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -151,10 +151,8 @@
     <authentication defaultProvider="switcher">
       <providers>
         <clear />
-        <add name="switcher"
-             type="Sitecore.FakeDb.Security.Authentication.SwitchingAuthenticationProvider, Sitecore.FakeDb">
-          <DefaultProvider
-              type="Sitecore.FakeDb.Security.Authentication.FakeAuthenticationProvider, Sitecore.FakeDb" />
+        <add name="switcher" type="Sitecore.FakeDb.Security.Authentication.SwitchingAuthenticationProvider, Sitecore.FakeDb">
+          <DefaultProvider type="Sitecore.FakeDb.Security.Authentication.FakeAuthenticationProvider, Sitecore.FakeDb" />
         </add>
       </providers>
     </authentication>
@@ -170,8 +168,7 @@
     <authorization>
       <providers>
         <clear />
-        <add name="fake"
-             type="Sitecore.FakeDb.Security.AccessControl.FakeAuthorizationProvider, Sitecore.FakeDb" />
+        <add name="fake" type="Sitecore.FakeDb.Security.AccessControl.FakeAuthorizationProvider, Sitecore.FakeDb" resolve="true" />
       </providers>
     </authorization>
     <!-- ACCESS RIGHTS -->

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -188,6 +188,10 @@
         <add name="switcher" type="Sitecore.FakeDb.ContentSearch.SwitchingSearchProvider, Sitecore.FakeDb" />
       </providers>
     </searchManager>
+    <services patch:source="Sitecore.ContentSearch.config">
+      <register serviceType="Sitecore.ContentSearch.ContentExtraction.IMediaFileTextExtractor, Sitecore.ContentSearch.ContentExtraction"
+                implementationType="Sitecore.ContentSearch.ContentExtraction.DefaultMediaTextExtractor, Sitecore.ContentSearch.ContentExtraction"/>
+    </services>
     <switchingProviders>
       <membership>
         <provider providerName="fake" storeFullNames="true" wildcard="%" domains="*" />

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -221,7 +221,6 @@
       <fieldType name="Image" type="Sitecore.Data.Fields.ImageField,Sitecore.Kernel" />
       <fieldType name="Rich Text" type="Sitecore.Data.Fields.HtmlField,Sitecore.Kernel" resizable="true" />
       <fieldType name="Single-Line Text" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" />
-      <fieldType name="Word Document" type="Sitecore.Data.Fields.WordDocumentField,Sitecore.Kernel" blob="true" />
       <fieldType name="Multi-Line Text" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
       <!-- List Types -->
       <fieldType name="Checklist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" resizable="true" />
@@ -229,8 +228,7 @@
       <fieldType name="Grouped Droplink" type="Sitecore.Data.Fields.GroupedDroplinkField,Sitecore.Kernel" />
       <fieldType name="Grouped Droplist" type="Sitecore.Data.Fields.GroupedDroplistField,Sitecore.Kernel" />
       <fieldType name="Multilist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" resizable="true" />
-      <fieldType name="Multilist with Search" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel"
-                 resizable="true" />
+      <fieldType name="Multilist with Search" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" resizable="true" />
       <fieldType name="Name Value List" type="Sitecore.Data.Fields.NameValueListField,Sitecore.Kernel" />
       <fieldType name="Treelist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
       <fieldType name="Treelist with Search" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
@@ -249,8 +247,7 @@
       <fieldType name="Custom" type="Sitecore.Data.Fields.CustomCustomField,Sitecore.Kernel" />
       <fieldType name="Internal Link" type="Sitecore.Data.Fields.InternalLinkField,Sitecore.Kernel" />
       <fieldType name="Layout" type="Sitecore.Data.Fields.LayoutField,Sitecore.Kernel" />
-      <fieldType name="Template Field Source"
-                 type="Sitecore.Data.Fields.TemplateFieldSourceField,Sitecore.Kernel" />
+      <fieldType name="Template Field Source" type="Sitecore.Data.Fields.TemplateFieldSourceField,Sitecore.Kernel" />
       <fieldType name="File Drop Area" type="Sitecore.Data.Fields.FileDropAreaField,Sitecore.Kernel" />
       <fieldType name="Page Preview" type="Sitecore.Data.Fields.PagePreviewField,Sitecore.Kernel" />
       <fieldType name="Rendering Datasource" type="Sitecore.Data.Fields.RenderingDatasourceField,Sitecore.Kernel" />

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -144,7 +144,7 @@
     <standardValues defaultProvider="fake">
       <providers>
         <clear />
-        <add name="fake" type="Sitecore.FakeDb.Data.FakeStandardValuesProvider, Sitecore.FakeDb" />
+        <add name="fake" type="Sitecore.FakeDb.Data.FakeStandardValuesProvider, Sitecore.FakeDb" resolve="true" />
       </providers>
     </standardValues>
     <!-- AUTHENTICATION -->

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -1,275 +1,275 @@
-﻿<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-    <sitecore database="Fake">
-        <!-- SETTINGS -->
-        <settings>
-            <setting name="LicenseFile" value="license.xml" />
-            <setting name="Caching.Enabled" value="false" />
-            <setting name="ItemNameValidation" value="^[\w\*\$][\w\s\-\$]*(\(\d{1,}\)){0,1}$" />
-            <setting name="MaxWorkerThreads" value="0" />
-            <setting name="FakeDb.AutoTranslate" value="false" />
-            <setting name="FakeDb.AutoTranslatePrefix" value="" />
-            <setting name="FakeDb.AutoTranslateSuffix" value="" />
-        </settings>
-        <!-- EVENTING -->
-        <eventing defaultProvider="sitecore">
-            <providers>
-                <clear />
-                <add name="sitecore" type="Sitecore.Eventing.EventProvider, Sitecore.Kernel" systemDatabaseName="core" />
-            </providers>
-        </eventing>
-        <!-- LINK DATABASE -->
-        <LinkDatabase type="Sitecore.FakeDb.Links.FakeLinkDatabase, Sitecore.FakeDb" />
-        <!-- TASK DATABASE -->
-        <TaskDatabase type="Sitecore.FakeDb.Tasks.FakeTaskDatabase, Sitecore.FakeDb" />
-        <!-- ID TABLE -->
-        <IDTable type="Sitecore.FakeDb.Data.IDTables.FakeIDTableProvider, Sitecore.FakeDb" singleInstance="true" />
-        <!-- PIPELINES -->
-        <pipelines>
-            <initialize />
-            <getFieldValue performanceCritical="true">
-                <processor type="Sitecore.Pipelines.GetFieldValue.GetInheritedValue, Sitecore.Kernel" />
-                <processor type="Sitecore.Pipelines.GetFieldValue.GetStandardValue, Sitecore.Kernel" />
-                <processor type="Sitecore.Pipelines.GetFieldValue.GetDefaultValue, Sitecore.Kernel" />
-            </getFieldValue>
-            <getLayoutSourceFields>
-                <processor type="Sitecore.Pipelines.GetLayoutSourceFields.GetFinalLayoutField, Sitecore.Kernel" />
-                <processor type="Sitecore.Pipelines.GetLayoutSourceFields.GetLayoutField, Sitecore.Kernel" />
-            </getLayoutSourceFields>
-            <!-- FakeDb -->
-            <initFakeDb>
-                <processor type="Sitecore.FakeDb.Pipelines.InitFakeDb.InitGlobals, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.Initialize.DisableLicenseWatcher, Sitecore.FakeDb" />
-            </initFakeDb>
-            <releaseFakeDb>
-                <processor type="Sitecore.FakeDb.Pipelines.ReleaseFakeDb.ReleasePipelineWatcher, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.ReleaseFakeDb.ResetTemplateEngine, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.ReleaseFakeDb.ResetFactory, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.ReleaseFakeDb.ResetSettings, Sitecore.FakeDb" />
-            </releaseFakeDb>
-            <addDbItem>
-                <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetStatistics, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetParent, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.CreateTemplate, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.EnsureIsChild, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetFullPath, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.AddVersion, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetAccess, Sitecore.FakeDb" />
-                <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetWorkflow, Sitecore.FakeDb" />
-            </addDbItem>
-            <getTranslation>
-                <processor type="Sitecore.FakeDb.Pipelines.GetTranslation.GetFakeTranslation, Sitecore.FakeDb" />
-            </getTranslation>
-            <!-- Analytics -->
-            <loadVisitor />
-        </pipelines>
-        <dataProviders>
-            <main type="Sitecore.FakeDb.Data.DataProviders.$(database)DataProvider, Sitecore.FakeDb">
-                <CacheOptions.DisableAll>true</CacheOptions.DisableAll>
-            </main>
-            <language type="Sitecore.FakeDb.Data.DataProviders.SwitchingLanguageDataProvider, Sitecore.FakeDb" />
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+  <sitecore database="Fake">
+    <!-- SETTINGS -->
+    <settings>
+      <setting name="LicenseFile" value="license.xml" />
+      <setting name="Caching.Enabled" value="false" />
+      <setting name="ItemNameValidation" value="^[\w\*\$][\w\s\-\$]*(\(\d{1,}\)){0,1}$" />
+      <setting name="MaxWorkerThreads" value="0" />
+      <setting name="FakeDb.AutoTranslate" value="false" />
+      <setting name="FakeDb.AutoTranslatePrefix" value="" />
+      <setting name="FakeDb.AutoTranslateSuffix" value="" />
+    </settings>
+    <!-- EVENTING -->
+    <eventing defaultProvider="sitecore">
+      <providers>
+        <clear />
+        <add name="sitecore" type="Sitecore.Eventing.EventProvider, Sitecore.Kernel" systemDatabaseName="core" />
+      </providers>
+    </eventing>
+    <!-- LINK DATABASE -->
+    <LinkDatabase type="Sitecore.FakeDb.Links.FakeLinkDatabase, Sitecore.FakeDb" />
+    <!-- TASK DATABASE -->
+    <TaskDatabase type="Sitecore.FakeDb.Tasks.FakeTaskDatabase, Sitecore.FakeDb" />
+    <!-- ID TABLE -->
+    <IDTable type="Sitecore.FakeDb.Data.IDTables.FakeIDTableProvider, Sitecore.FakeDb" singleInstance="true" />
+    <!-- PIPELINES -->
+    <pipelines>
+      <initialize />
+      <getFieldValue performanceCritical="true">
+        <processor type="Sitecore.Pipelines.GetFieldValue.GetInheritedValue, Sitecore.Kernel" />
+        <processor type="Sitecore.Pipelines.GetFieldValue.GetStandardValue, Sitecore.Kernel" />
+        <processor type="Sitecore.Pipelines.GetFieldValue.GetDefaultValue, Sitecore.Kernel" />
+      </getFieldValue>
+      <getLayoutSourceFields>
+        <processor type="Sitecore.Pipelines.GetLayoutSourceFields.GetFinalLayoutField, Sitecore.Kernel" />
+        <processor type="Sitecore.Pipelines.GetLayoutSourceFields.GetLayoutField, Sitecore.Kernel" />
+      </getLayoutSourceFields>
+      <!-- FakeDb -->
+      <initFakeDb>
+        <processor type="Sitecore.FakeDb.Pipelines.InitFakeDb.InitGlobals, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.Initialize.DisableLicenseWatcher, Sitecore.FakeDb" />
+      </initFakeDb>
+      <releaseFakeDb>
+        <processor type="Sitecore.FakeDb.Pipelines.ReleaseFakeDb.ReleasePipelineWatcher, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.ReleaseFakeDb.ResetTemplateEngine, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.ReleaseFakeDb.ResetFactory, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.ReleaseFakeDb.ResetSettings, Sitecore.FakeDb" />
+      </releaseFakeDb>
+      <addDbItem>
+        <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetStatistics, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetParent, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.CreateTemplate, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.EnsureIsChild, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetFullPath, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.AddVersion, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetAccess, Sitecore.FakeDb" />
+        <processor type="Sitecore.FakeDb.Pipelines.AddDbItem.SetWorkflow, Sitecore.FakeDb" />
+      </addDbItem>
+      <getTranslation>
+        <processor type="Sitecore.FakeDb.Pipelines.GetTranslation.GetFakeTranslation, Sitecore.FakeDb" />
+      </getTranslation>
+      <!-- Analytics -->
+      <loadVisitor />
+    </pipelines>
+    <dataProviders>
+      <main type="Sitecore.FakeDb.Data.DataProviders.$(database)DataProvider, Sitecore.FakeDb">
+        <CacheOptions.DisableAll>true</CacheOptions.DisableAll>
+      </main>
+      <language type="Sitecore.FakeDb.Data.DataProviders.SwitchingLanguageDataProvider, Sitecore.FakeDb" />
+    </dataProviders>
+    <!-- DATABASES -->
+    <databases>
+      <!-- core -->
+      <database id="core" type="$(databaseType)" singleInstance="true">
+        <param desc="name">$(id)</param>
+        <dataProviders hint="list:AddDataProvider">
+          <dataProvider ref="dataProviders/main" />
+          <dataProvider ref="dataProviders/language" />
         </dataProviders>
-        <!-- DATABASES -->
-        <databases>
-            <!-- core -->
-            <database id="core" type="$(databaseType)" singleInstance="true">
-                <param desc="name">$(id)</param>
-                <dataProviders hint="list:AddDataProvider">
-                    <dataProvider ref="dataProviders/main" />
-                    <dataProvider ref="dataProviders/language" />
-                </dataProviders>
-            </database>
-            <!-- master -->
-            <database id="master" type="$(databaseType)" singleInstance="true">
-                <param desc="name">$(id)</param>
-                <dataProviders hint="list:AddDataProvider">
-                    <dataProvider ref="dataProviders/main" />
-                    <dataProvider ref="dataProviders/language" />
-                </dataProviders>
-            </database>
-            <!-- web -->
-            <database id="web" type="$(databaseType)" singleInstance="true">
-                <param desc="name">$(id)</param>
-                <dataProviders hint="list:AddDataProvider">
-                    <dataProvider ref="dataProviders/main" />
-                    <dataProvider ref="dataProviders/language" />
-                </dataProviders>
-            </database>
-        </databases>
-        <archives defaultProvider="sql" enabled="true">
-            <providers>
-                <clear />
-                <add name="sql" type="Sitecore.Data.Archiving.SqlArchiveProvider, Sitecore.Kernel" database="*" />
-            </providers>
-        </archives>
-        <clientDataStore type="Sitecore.FakeDb.Configuration.ClientDataStoreStub, Sitecore.FakeDb" />
-        <!-- CONFIG STORES -->
-        <configStores>
-            <add name="globalRoles" type="Sitecore.Configuration.XmlConfigStore, Sitecore.Kernel">
-                <param>roles</param>
-            </add>
-        </configStores>
-        <!-- ITEM MANAGER -->
-        <itemManager defaultProvider="default">
-            <providers>
-                <clear />
-                <add name="default" type="Sitecore.Data.Managers.ItemProvider, Sitecore.Kernel" />
-            </providers>
-        </itemManager>
-        <!-- DOMAINS -->
-        <domainManager>
-            <providers>
-                <clear />
-                <add name="fake" type="Sitecore.FakeDb.SecurityModel.FakeDomainProvider, Sitecore.FakeDb" />
-            </providers>
-        </domainManager>
-        <!-- SITES -->
-        <siteManager defaultProvider="config">
-            <providers>
-                <clear />
-                <add name="config" type="Sitecore.Sites.ConfigSiteProvider, Sitecore.Kernel" siteList="sites"
-                     checkSecurity="false" />
-            </providers>
-        </siteManager>
-        <!-- LINKS -->
-        <linkManager defaultProvider="sitecore">
-            <providers>
-                <clear />
-                <add name="sitecore" type="Sitecore.Links.LinkProvider, Sitecore.Kernel" addAspxExtension="true"
-                     alwaysIncludeServerUrl="false" encodeNames="true" languageEmbedding="asNeeded"
-                     languageLocation="filePath" lowercaseUrls="false" shortenUrls="true" useDisplayName="false" />
-                <add name="switcher" type="Sitecore.FakeDb.Links.SwitchingLinkProvider, Sitecore.FakeDb" />
-            </providers>
-        </linkManager>
-        <!-- STANDARD VALUES -->
-        <standardValues defaultProvider="fake">
-            <providers>
-                <clear />
-                <add name="fake" type="Sitecore.FakeDb.Data.FakeStandardValuesProvider, Sitecore.FakeDb" />
-            </providers>
-        </standardValues>
-        <!-- AUTHENTICATION -->
-        <authentication defaultProvider="switcher">
-            <providers>
-                <clear />
-                <add name="switcher"
-                     type="Sitecore.FakeDb.Security.Authentication.SwitchingAuthenticationProvider, Sitecore.FakeDb">
-                    <DefaultProvider
-                        type="Sitecore.FakeDb.Security.Authentication.FakeAuthenticationProvider, Sitecore.FakeDb" />
-                </add>
-            </providers>
-        </authentication>
-        <!-- ROLES -->
-        <rolesInRolesManager>
-            <providers>
-                <clear />
-                <add name="fake" type="Sitecore.FakeDb.Security.Accounts.FakeRolesInRolesProvider, Sitecore.FakeDb"
-                     globalRolesConfigStoreName="globalRoles" />
-            </providers>
-        </rolesInRolesManager>
-        <!-- AUTHORIZATION -->
-        <authorization>
-            <providers>
-                <clear />
-                <add name="fake"
-                     type="Sitecore.FakeDb.Security.AccessControl.FakeAuthorizationProvider, Sitecore.FakeDb" />
-            </providers>
-        </authorization>
-        <!-- ACCESS RIGHTS -->
-        <accessRights>
-            <providers>
-                <clear />
-                <add name="fake" type="Sitecore.FakeDb.Security.AccessControl.FakeAccessRightProvider, Sitecore.FakeDb" />
-            </providers>
-        </accessRights>
-        <!-- SEARCH -->
-        <contentSearch>
+      </database>
+      <!-- master -->
+      <database id="master" type="$(databaseType)" singleInstance="true">
+        <param desc="name">$(id)</param>
+        <dataProviders hint="list:AddDataProvider">
+          <dataProvider ref="dataProviders/main" />
+          <dataProvider ref="dataProviders/language" />
+        </dataProviders>
+      </database>
+      <!-- web -->
+      <database id="web" type="$(databaseType)" singleInstance="true">
+        <param desc="name">$(id)</param>
+        <dataProviders hint="list:AddDataProvider">
+          <dataProvider ref="dataProviders/main" />
+          <dataProvider ref="dataProviders/language" />
+        </dataProviders>
+      </database>
+    </databases>
+    <archives defaultProvider="sql" enabled="true">
+      <providers>
+        <clear />
+        <add name="sql" type="Sitecore.Data.Archiving.SqlArchiveProvider, Sitecore.Kernel" database="*" />
+      </providers>
+    </archives>
+    <clientDataStore type="Sitecore.FakeDb.Configuration.ClientDataStoreStub, Sitecore.FakeDb" />
+    <!-- CONFIG STORES -->
+    <configStores>
+      <add name="globalRoles" type="Sitecore.Configuration.XmlConfigStore, Sitecore.Kernel">
+        <param>roles</param>
+      </add>
+    </configStores>
+    <!-- ITEM MANAGER -->
+    <itemManager defaultProvider="default">
+      <providers>
+        <clear />
+        <add name="default" type="Sitecore.Data.Managers.ItemProvider, Sitecore.Kernel" resolve="true" />
+      </providers>
+    </itemManager>
+    <!-- DOMAINS -->
+    <domainManager>
+      <providers>
+        <clear />
+        <add name="fake" type="Sitecore.FakeDb.SecurityModel.FakeDomainProvider, Sitecore.FakeDb" />
+      </providers>
+    </domainManager>
+    <!-- SITES -->
+    <siteManager defaultProvider="config">
+      <providers>
+        <clear />
+        <add name="config" type="Sitecore.Sites.ConfigSiteProvider, Sitecore.Kernel" siteList="sites"
+             checkSecurity="false" />
+      </providers>
+    </siteManager>
+    <!-- LINKS -->
+    <linkManager defaultProvider="sitecore">
+      <providers>
+        <clear />
+        <add name="sitecore" type="Sitecore.Links.LinkProvider, Sitecore.Kernel" addAspxExtension="true"
+             alwaysIncludeServerUrl="false" encodeNames="true" languageEmbedding="asNeeded"
+             languageLocation="filePath" lowercaseUrls="false" shortenUrls="true" useDisplayName="false" />
+        <add name="switcher" type="Sitecore.FakeDb.Links.SwitchingLinkProvider, Sitecore.FakeDb" />
+      </providers>
+    </linkManager>
+    <!-- STANDARD VALUES -->
+    <standardValues defaultProvider="fake">
+      <providers>
+        <clear />
+        <add name="fake" type="Sitecore.FakeDb.Data.FakeStandardValuesProvider, Sitecore.FakeDb" />
+      </providers>
+    </standardValues>
+    <!-- AUTHENTICATION -->
+    <authentication defaultProvider="switcher">
+      <providers>
+        <clear />
+        <add name="switcher"
+             type="Sitecore.FakeDb.Security.Authentication.SwitchingAuthenticationProvider, Sitecore.FakeDb">
+          <DefaultProvider
+              type="Sitecore.FakeDb.Security.Authentication.FakeAuthenticationProvider, Sitecore.FakeDb" />
+        </add>
+      </providers>
+    </authentication>
+    <!-- ROLES -->
+    <rolesInRolesManager>
+      <providers>
+        <clear />
+        <add name="fake" type="Sitecore.FakeDb.Security.Accounts.FakeRolesInRolesProvider, Sitecore.FakeDb"
+             globalRolesConfigStoreName="globalRoles" />
+      </providers>
+    </rolesInRolesManager>
+    <!-- AUTHORIZATION -->
+    <authorization>
+      <providers>
+        <clear />
+        <add name="fake"
+             type="Sitecore.FakeDb.Security.AccessControl.FakeAuthorizationProvider, Sitecore.FakeDb" />
+      </providers>
+    </authorization>
+    <!-- ACCESS RIGHTS -->
+    <accessRights>
+      <providers>
+        <clear />
+        <add name="fake" type="Sitecore.FakeDb.Security.AccessControl.FakeAccessRightProvider, Sitecore.FakeDb" />
+      </providers>
+    </accessRights>
+    <!-- SEARCH -->
+    <contentSearch>
       <configuration type="Sitecore.ContentSearch.ContentSearchConfiguration, Sitecore.ContentSearch" />
-        </contentSearch>
-        <searchManager defaultProvider="switcher" enabled="true">
-            <providers>
-                <clear />
-                <add name="switcher" type="Sitecore.FakeDb.ContentSearch.SwitchingSearchProvider, Sitecore.FakeDb" />
-            </providers>
-        </searchManager>
-        <switchingProviders>
-            <membership>
-                <provider providerName="fake" storeFullNames="true" wildcard="%" domains="*" />
-            </membership>
-            <roleManager>
-                <provider providerName="fake" storeFullNames="true" wildcard="%" domains="*" />
-            </roleManager>
-            <profile>
-                <provider providerName="fake" storeFullNames="true" wildcard="%" domains="*" />
-            </profile>
-        </switchingProviders>
-        <mediaLibrary>
-            <!-- MEDIA PROVIDER -->
-            <mediaProvider type="Sitecore.FakeDb.Resources.Media.FakeMediaProvider, Sitecore.FakeDb" />
-        </mediaLibrary>
-        <bucketManager defaultProvider="switcher" enabled="true">
-            <providers>
-                <clear />
-                <add name="switcher" type="Sitecore.FakeDb.Buckets.SwitchingBucketProvider, Sitecore.FakeDb" />
-            </providers>
-        </bucketManager>
-        <!-- FIELD TYPES -->
-        <fieldTypes>
-            <!-- Defines the releation between a field type name, e.g. "lookup", and an implementation class -->
+    </contentSearch>
+    <searchManager defaultProvider="switcher" enabled="true">
+      <providers>
+        <clear />
+        <add name="switcher" type="Sitecore.FakeDb.ContentSearch.SwitchingSearchProvider, Sitecore.FakeDb" />
+      </providers>
+    </searchManager>
+    <switchingProviders>
+      <membership>
+        <provider providerName="fake" storeFullNames="true" wildcard="%" domains="*" />
+      </membership>
+      <roleManager>
+        <provider providerName="fake" storeFullNames="true" wildcard="%" domains="*" />
+      </roleManager>
+      <profile>
+        <provider providerName="fake" storeFullNames="true" wildcard="%" domains="*" />
+      </profile>
+    </switchingProviders>
+    <mediaLibrary>
+      <!-- MEDIA PROVIDER -->
+      <mediaProvider type="Sitecore.FakeDb.Resources.Media.FakeMediaProvider, Sitecore.FakeDb" />
+    </mediaLibrary>
+    <bucketManager defaultProvider="switcher" enabled="true">
+      <providers>
+        <clear />
+        <add name="switcher" type="Sitecore.FakeDb.Buckets.SwitchingBucketProvider, Sitecore.FakeDb" />
+      </providers>
+    </bucketManager>
+    <!-- FIELD TYPES -->
+    <fieldTypes>
+      <!-- Defines the releation between a field type name, e.g. "lookup", and an implementation class -->
 
-            <!-- Simple Types -->
-            <fieldType name="Checkbox" type="Sitecore.Data.Fields.CheckboxField,Sitecore.Kernel" />
-            <fieldType name="Date" type="Sitecore.Data.Fields.DateField,Sitecore.Kernel" />
-            <fieldType name="Datetime" type="Sitecore.Data.Fields.DateField,Sitecore.Kernel" />
-            <fieldType name="File" type="Sitecore.Data.Fields.FileField,Sitecore.Kernel" />
-            <fieldType name="Image" type="Sitecore.Data.Fields.ImageField,Sitecore.Kernel" />
-            <fieldType name="Rich Text" type="Sitecore.Data.Fields.HtmlField,Sitecore.Kernel" resizable="true" />
-            <fieldType name="Single-Line Text" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" />
-            <fieldType name="Word Document" type="Sitecore.Data.Fields.WordDocumentField,Sitecore.Kernel" blob="true" />
-            <fieldType name="Multi-Line Text" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
-            <!-- List Types -->
-            <fieldType name="Checklist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" resizable="true" />
-            <fieldType name="Droplist" type="Sitecore.Data.Fields.ValueLookupField,Sitecore.Kernel" />
-            <fieldType name="Grouped Droplink" type="Sitecore.Data.Fields.GroupedDroplinkField,Sitecore.Kernel" />
-            <fieldType name="Grouped Droplist" type="Sitecore.Data.Fields.GroupedDroplistField,Sitecore.Kernel" />
-            <fieldType name="Multilist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" resizable="true" />
-            <fieldType name="Multilist with Search" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel"
-                       resizable="true" />
-            <fieldType name="Name Value List" type="Sitecore.Data.Fields.NameValueListField,Sitecore.Kernel" />
-            <fieldType name="Treelist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
-            <fieldType name="Treelist with Search" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
-            <fieldType name="TreelistEx" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
-            <!-- Link Types -->
-            <fieldType name="Droplink" type="Sitecore.Data.Fields.LookupField,Sitecore.Kernel" />
-            <fieldType name="Droptree" type="Sitecore.Data.Fields.ReferenceField,Sitecore.Kernel" />
-            <fieldType name="General Link" type="Sitecore.Data.Fields.LinkField,Sitecore.Kernel" />
-            <fieldType name="General Link with Search" type="Sitecore.Data.Fields.LinkField,Sitecore.Kernel" />
-            <fieldType name="Version Link" type="Sitecore.Data.Fields.VersionLinkField,Sitecore.Kernel" />
-            <!-- Developer Types -->
-            <fieldType name="Frame" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
-            <fieldType name="Rules" type="Sitecore.Data.Fields.RulesField,Sitecore.Kernel" resizable="true" />
-            <!-- System Types -->
-            <fieldType name="Datasource" type="Sitecore.Data.Fields.DatasourceField,Sitecore.Kernel" />
-            <fieldType name="Custom" type="Sitecore.Data.Fields.CustomCustomField,Sitecore.Kernel" />
-            <fieldType name="Internal Link" type="Sitecore.Data.Fields.InternalLinkField,Sitecore.Kernel" />
-            <fieldType name="Layout" type="Sitecore.Data.Fields.LayoutField,Sitecore.Kernel" />
-            <fieldType name="Template Field Source"
-                       type="Sitecore.Data.Fields.TemplateFieldSourceField,Sitecore.Kernel" />
-            <fieldType name="File Drop Area" type="Sitecore.Data.Fields.FileDropAreaField,Sitecore.Kernel" />
-            <fieldType name="Page Preview" type="Sitecore.Data.Fields.PagePreviewField,Sitecore.Kernel" />
-            <fieldType name="Rendering Datasource" type="Sitecore.Data.Fields.RenderingDatasourceField,Sitecore.Kernel" />
-            <fieldType name="Thumbnail" type="Sitecore.Data.Fields.ThumbnailField,Sitecore.Kernel" />
-            <fieldType name="Security" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
-            <fieldType name="UserList" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
-            <!-- Deprecated Types -->
-            <fieldType name="html" type="Sitecore.Data.Fields.HtmlField,Sitecore.Kernel" resizable="true" />
-            <fieldType name="link" type="Sitecore.Data.Fields.LinkField,Sitecore.Kernel" />
-            <fieldType name="lookup" type="Sitecore.Data.Fields.LookupField,Sitecore.Kernel" />
-            <fieldType name="reference" type="Sitecore.Data.Fields.ReferenceField,Sitecore.Kernel" />
-            <fieldType name="text" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" />
-            <fieldType name="memo" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
-            <fieldType name="tree" type="Sitecore.Data.Fields.ReferenceField,Sitecore.Kernel" />
-            <fieldType name="tree list" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
-            <fieldType name="valuelookup" type="Sitecore.Data.Fields.ValueLookupField,Sitecore.Kernel" />
-        </fieldTypes>
-    </sitecore>
+      <!-- Simple Types -->
+      <fieldType name="Checkbox" type="Sitecore.Data.Fields.CheckboxField,Sitecore.Kernel" />
+      <fieldType name="Date" type="Sitecore.Data.Fields.DateField,Sitecore.Kernel" />
+      <fieldType name="Datetime" type="Sitecore.Data.Fields.DateField,Sitecore.Kernel" />
+      <fieldType name="File" type="Sitecore.Data.Fields.FileField,Sitecore.Kernel" />
+      <fieldType name="Image" type="Sitecore.Data.Fields.ImageField,Sitecore.Kernel" />
+      <fieldType name="Rich Text" type="Sitecore.Data.Fields.HtmlField,Sitecore.Kernel" resizable="true" />
+      <fieldType name="Single-Line Text" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" />
+      <fieldType name="Word Document" type="Sitecore.Data.Fields.WordDocumentField,Sitecore.Kernel" blob="true" />
+      <fieldType name="Multi-Line Text" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
+      <!-- List Types -->
+      <fieldType name="Checklist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" resizable="true" />
+      <fieldType name="Droplist" type="Sitecore.Data.Fields.ValueLookupField,Sitecore.Kernel" />
+      <fieldType name="Grouped Droplink" type="Sitecore.Data.Fields.GroupedDroplinkField,Sitecore.Kernel" />
+      <fieldType name="Grouped Droplist" type="Sitecore.Data.Fields.GroupedDroplistField,Sitecore.Kernel" />
+      <fieldType name="Multilist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" resizable="true" />
+      <fieldType name="Multilist with Search" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel"
+                 resizable="true" />
+      <fieldType name="Name Value List" type="Sitecore.Data.Fields.NameValueListField,Sitecore.Kernel" />
+      <fieldType name="Treelist" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
+      <fieldType name="Treelist with Search" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
+      <fieldType name="TreelistEx" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
+      <!-- Link Types -->
+      <fieldType name="Droplink" type="Sitecore.Data.Fields.LookupField,Sitecore.Kernel" />
+      <fieldType name="Droptree" type="Sitecore.Data.Fields.ReferenceField,Sitecore.Kernel" />
+      <fieldType name="General Link" type="Sitecore.Data.Fields.LinkField,Sitecore.Kernel" />
+      <fieldType name="General Link with Search" type="Sitecore.Data.Fields.LinkField,Sitecore.Kernel" />
+      <fieldType name="Version Link" type="Sitecore.Data.Fields.VersionLinkField,Sitecore.Kernel" />
+      <!-- Developer Types -->
+      <fieldType name="Frame" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
+      <fieldType name="Rules" type="Sitecore.Data.Fields.RulesField,Sitecore.Kernel" resizable="true" />
+      <!-- System Types -->
+      <fieldType name="Datasource" type="Sitecore.Data.Fields.DatasourceField,Sitecore.Kernel" />
+      <fieldType name="Custom" type="Sitecore.Data.Fields.CustomCustomField,Sitecore.Kernel" />
+      <fieldType name="Internal Link" type="Sitecore.Data.Fields.InternalLinkField,Sitecore.Kernel" />
+      <fieldType name="Layout" type="Sitecore.Data.Fields.LayoutField,Sitecore.Kernel" />
+      <fieldType name="Template Field Source"
+                 type="Sitecore.Data.Fields.TemplateFieldSourceField,Sitecore.Kernel" />
+      <fieldType name="File Drop Area" type="Sitecore.Data.Fields.FileDropAreaField,Sitecore.Kernel" />
+      <fieldType name="Page Preview" type="Sitecore.Data.Fields.PagePreviewField,Sitecore.Kernel" />
+      <fieldType name="Rendering Datasource" type="Sitecore.Data.Fields.RenderingDatasourceField,Sitecore.Kernel" />
+      <fieldType name="Thumbnail" type="Sitecore.Data.Fields.ThumbnailField,Sitecore.Kernel" />
+      <fieldType name="Security" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
+      <fieldType name="UserList" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
+      <!-- Deprecated Types -->
+      <fieldType name="html" type="Sitecore.Data.Fields.HtmlField,Sitecore.Kernel" resizable="true" />
+      <fieldType name="link" type="Sitecore.Data.Fields.LinkField,Sitecore.Kernel" />
+      <fieldType name="lookup" type="Sitecore.Data.Fields.LookupField,Sitecore.Kernel" />
+      <fieldType name="reference" type="Sitecore.Data.Fields.ReferenceField,Sitecore.Kernel" />
+      <fieldType name="text" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" />
+      <fieldType name="memo" type="Sitecore.Data.Fields.TextField,Sitecore.Kernel" resizable="true" />
+      <fieldType name="tree" type="Sitecore.Data.Fields.ReferenceField,Sitecore.Kernel" />
+      <fieldType name="tree list" type="Sitecore.Data.Fields.MultilistField,Sitecore.Kernel" />
+      <fieldType name="valuelookup" type="Sitecore.Data.Fields.ValueLookupField,Sitecore.Kernel" />
+    </fieldTypes>
+  </sitecore>
 </configuration>

--- a/src/Sitecore.FakeDb/Sitecore.config
+++ b/src/Sitecore.FakeDb/Sitecore.config
@@ -134,12 +134,16 @@
     <linkManager defaultProvider="sitecore">
       <providers>
         <clear />
-        <add name="sitecore" type="Sitecore.Links.LinkProvider, Sitecore.Kernel" addAspxExtension="true"
-             alwaysIncludeServerUrl="false" encodeNames="true" languageEmbedding="asNeeded"
-             languageLocation="filePath" lowercaseUrls="false" shortenUrls="true" useDisplayName="false" />
+        <add name="sitecore" type="Sitecore.Links.LinkProvider, Sitecore.Kernel" resolve="true" />
         <add name="switcher" type="Sitecore.FakeDb.Links.SwitchingLinkProvider, Sitecore.FakeDb" />
       </providers>
     </linkManager>
+    <links>
+      <itemUrlBuilder type="Sitecore.Links.UrlBuilders.ItemUrlBuilder, Sitecore.Kernel">
+        <param desc="defaultOptions" type="Sitecore.Links.UrlBuilders.DefaultItemUrlBuilderOptions, Sitecore.Kernel">
+        </param>
+      </itemUrlBuilder>
+    </links>
     <!-- STANDARD VALUES -->
     <standardValues defaultProvider="fake">
       <providers>
@@ -160,8 +164,7 @@
     <rolesInRolesManager>
       <providers>
         <clear />
-        <add name="fake" type="Sitecore.FakeDb.Security.Accounts.FakeRolesInRolesProvider, Sitecore.FakeDb"
-             globalRolesConfigStoreName="globalRoles" />
+        <add name="fake" type="Sitecore.FakeDb.Security.Accounts.FakeRolesInRolesProvider, Sitecore.FakeDb" globalRolesConfigStoreName="globalRoles" />
       </providers>
     </rolesInRolesManager>
     <!-- AUTHORIZATION -->

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
@@ -38,6 +38,10 @@
                 <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <startup>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
@@ -30,6 +30,14 @@
                 <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <startup>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
@@ -20,11 +20,11 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
@@ -16,7 +16,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.0.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-4.11.0.0" newVersion="4.11.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
@@ -12,7 +12,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/App.config
@@ -8,7 +8,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.4049" newVersion="2.4.0.4049" />
+                <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/ContentSearchProviderSample.cs
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Samples/ContentSearchProviderSample.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.AutoFixture.Tests.Samples
+namespace Sitecore.FakeDb.AutoFixture.Tests.Samples
 {
     using System;
     using System.Collections.Generic;
@@ -47,7 +47,7 @@
                         }.AsQueryable());
 
                 ContentSearchManager.SearchConfiguration.Indexes["indexName"] = searchIndex;
-                provider.GetContextIndexName(indexable, Arg.Any<ICorePipeline>()).Returns("indexName");
+                provider.GetContextIndexName(indexable, Arg.Any<BaseCorePipelineManager>()).Returns("indexName");
 
                 // act
                 var products = sut.GetProducts(indexable);

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\version.props" />
   <PropertyGroup>
@@ -134,16 +134,17 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.2\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.4.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -214,9 +215,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -76,10 +76,6 @@
     <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Abstractions, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Sitecore.Abstractions.dll</HintPath>
-    </Reference>
     <Reference Include="Sitecore.Buckets">
       <HintPath>..\..\lib\Sitecore.Buckets.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -89,8 +89,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=4.2.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.4.2.1\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Buckets">
       <HintPath>..\..\lib\Sitecore.Buckets.dll</HintPath>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -60,11 +60,11 @@
       <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.2.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\version.props" />
@@ -215,6 +216,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
 </Project>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -66,6 +66,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -72,6 +72,9 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -38,14 +38,14 @@
     <CodeAnalysisRuleSet>..\..\Sitecore.FakeDb.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    <Reference Include="AutoFixture, Version=4.11.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.4.11.0\lib\net452\AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.AutoNSubstitute.4.0.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
+    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.11.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.AutoNSubstitute.4.11.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="AutoFixture.Xunit2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.Xunit2.4.0.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    <Reference Include="AutoFixture.Xunit2, Version=4.11.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.Xunit2.4.11.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/Sitecore.FakeDb.AutoFixture.Tests.csproj
@@ -66,6 +66,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -7,8 +7,8 @@
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="Fare" version="2.1.1" targetFramework="net452" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -9,6 +9,8 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
+  <package id="NSubstitute" version="4.2.1" targetFramework="net471" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.Nexus.Licensing" version="2.0.6" targetFramework="net471" />
   <package id="System.Security.Cryptography.Xml" version="4.6.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="4.0.0" targetFramework="net452" />
-  <package id="AutoFixture.AutoNSubstitute" version="4.0.0" targetFramework="net452" />
-  <package id="AutoFixture.Xunit2" version="4.0.0" targetFramework="net452" />
+  <package id="AutoFixture" version="4.11.0" targetFramework="net471" />
+  <package id="AutoFixture.AutoNSubstitute" version="4.11.0" targetFramework="net471" />
+  <package id="AutoFixture.Xunit2" version="4.11.0" targetFramework="net471" />
   <package id="Castle.Core" version="4.2.0" targetFramework="net452" />
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="Fare" version="2.1.1" targetFramework="net452" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -9,6 +9,8 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -27,4 +27,5 @@
   <package id="xunit.core" version="2.4.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -20,12 +20,12 @@
   <package id="Sitecore.Nexus.Licensing" version="2.0.6" targetFramework="net471" />
   <package id="System.Security.Cryptography.Xml" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />
-  <package id="xunit" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.2" targetFramework="net452" />
-  <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.4.0" targetFramework="net452" requireReinstallation="true" />
-  <package id="xunit.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net471" developmentDependency="true" />
+  <package id="xunit" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net471" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net471" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
+++ b/test/Sitecore.FakeDb.AutoFixture.Tests/packages.config
@@ -11,6 +11,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
@@ -13,7 +13,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.4049" newVersion="2.4.0.4049" />
+                <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
@@ -21,7 +21,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.0.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-4.11.0.0" newVersion="4.11.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
@@ -43,6 +43,10 @@
                 <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <startup>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
@@ -25,11 +25,11 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
@@ -17,7 +17,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/App.config
@@ -35,6 +35,14 @@
                 <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <startup>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
@@ -55,6 +55,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
@@ -55,6 +55,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
@@ -61,6 +61,9 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
@@ -78,8 +78,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=4.2.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.4.2.1\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.ContentSearch.ContentExtraction, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Sitecore.ContentSearch.ContentExtraction.9.2.0\lib\net471\Sitecore.ContentSearch.ContentExtraction.dll</HintPath>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\version.props" />
   <PropertyGroup>
@@ -108,16 +108,17 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.2\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.4.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -168,9 +169,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\version.props" />
@@ -169,6 +170,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
 </Project>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/Sitecore.FakeDb.NSubstitute.Tests.csproj
@@ -49,11 +49,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.2.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
@@ -23,4 +23,5 @@
   <package id="xunit.core" version="2.4.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
@@ -5,6 +5,8 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
@@ -16,12 +16,12 @@
   <package id="Sitecore.Nexus.Licensing" version="2.0.6" targetFramework="net471" />
   <package id="System.Security.Cryptography.Xml" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />
-  <package id="xunit" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.2" targetFramework="net452" />
-  <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.4.0" targetFramework="net452" requireReinstallation="true" />
-  <package id="xunit.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net471" developmentDependency="true" />
+  <package id="xunit" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net471" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net471" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
@@ -3,8 +3,8 @@
   <package id="Castle.Core" version="4.2.0" targetFramework="net452" />
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
+  <package id="NSubstitute" version="4.2.1" targetFramework="net471" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.Nexus.Licensing" version="2.0.6" targetFramework="net471" />
   <package id="System.Security.Cryptography.Xml" version="4.6.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
@@ -5,6 +5,8 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NSubstitute.Tests/packages.config
@@ -7,6 +7,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/App.config
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/App.config
@@ -25,6 +25,10 @@
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/App.config
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/App.config
@@ -17,6 +17,14 @@
         <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/App.config
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/App.config
@@ -7,11 +7,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
@@ -36,11 +36,11 @@
     <CodeAnalysisRuleSet>..\..\Sitecore.FakeDb.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.2.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
@@ -48,6 +48,9 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
@@ -42,6 +42,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/Sitecore.FakeDb.NUnitLite.Tests.csproj
@@ -42,6 +42,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
@@ -3,6 +3,8 @@
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
@@ -3,6 +3,8 @@
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="NUnitLite" version="3.4.1" targetFramework="net45" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
+++ b/test/Sitecore.FakeDb.NUnitLite.Tests/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="NUnitLite" version="3.4.1" targetFramework="net45" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/App.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/App.config
@@ -41,11 +41,11 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/App.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/App.config
@@ -29,7 +29,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.4049" newVersion="2.4.0.4049" />
+                <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/App.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/App.config
@@ -33,7 +33,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/App.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/App.config
@@ -37,7 +37,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.0.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-4.11.0.0" newVersion="4.11.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/App.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/App.config
@@ -59,6 +59,10 @@
                 <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <startup>

--- a/test/Sitecore.FakeDb.Serialization.Tests/App.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/App.config
@@ -51,6 +51,14 @@
                 <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <startup>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\version.props" />
@@ -205,6 +206,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
 </Project>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -38,11 +38,11 @@
     <CodeAnalysisRuleSet>..\..\Sitecore.FakeDb.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    <Reference Include="AutoFixture, Version=4.11.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.4.11.0\lib\net452\AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.AutoNSubstitute.4.0.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
+    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.11.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.AutoNSubstitute.4.11.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -86,8 +86,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=4.2.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.4.2.1\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.ContentSearch.ContentExtraction, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Sitecore.ContentSearch.ContentExtraction.9.2.0\lib\net471\Sitecore.ContentSearch.ContentExtraction.dll</HintPath>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -69,6 +69,9 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -63,6 +63,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\version.props" />
   <PropertyGroup>
@@ -119,16 +119,17 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.2\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.4.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -204,9 +205,10 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -57,11 +57,11 @@
       <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.2.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>

--- a/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
+++ b/test/Sitecore.FakeDb.Serialization.Tests/Sitecore.FakeDb.Serialization.Tests.csproj
@@ -63,6 +63,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="4.0.0" targetFramework="net452" />
-  <package id="AutoFixture.AutoNSubstitute" version="4.0.0" targetFramework="net452" />
+  <package id="AutoFixture" version="4.11.0" targetFramework="net471" />
+  <package id="AutoFixture.AutoNSubstitute" version="4.11.0" targetFramework="net471" />
   <package id="Castle.Core" version="4.2.0" targetFramework="net452" />
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="Fare" version="2.1.1" targetFramework="net452" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -26,4 +26,5 @@
   <package id="xunit.core" version="2.4.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -8,6 +8,8 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -19,12 +19,12 @@
   <package id="Sitecore.Nexus.Licensing" version="2.0.6" targetFramework="net471" />
   <package id="System.Security.Cryptography.Xml" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />
-  <package id="xunit" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.2" targetFramework="net452" />
-  <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.4.0" targetFramework="net452" requireReinstallation="true" />
-  <package id="xunit.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net471" developmentDependency="true" />
+  <package id="xunit" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net471" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net471" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -6,8 +6,8 @@
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="Fare" version="2.1.1" targetFramework="net452" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -8,6 +8,8 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.Serialization.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Serialization.Tests/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
+  <package id="NSubstitute" version="4.2.1" targetFramework="net471" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.Nexus.Licensing" version="2.0.6" targetFramework="net471" />
   <package id="System.Security.Cryptography.Xml" version="4.6.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.Tests/App.config
+++ b/test/Sitecore.FakeDb.Tests/App.config
@@ -49,7 +49,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />

--- a/test/Sitecore.FakeDb.Tests/App.config
+++ b/test/Sitecore.FakeDb.Tests/App.config
@@ -61,11 +61,11 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/test/Sitecore.FakeDb.Tests/App.config
+++ b/test/Sitecore.FakeDb.Tests/App.config
@@ -53,7 +53,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.4.0.4049" newVersion="2.4.0.4049" />
+                <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />

--- a/test/Sitecore.FakeDb.Tests/App.config
+++ b/test/Sitecore.FakeDb.Tests/App.config
@@ -71,6 +71,14 @@
                 <assemblyIdentity name="System.Security.Cryptography.Xml" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <startup>

--- a/test/Sitecore.FakeDb.Tests/App.config
+++ b/test/Sitecore.FakeDb.Tests/App.config
@@ -79,6 +79,10 @@
                 <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <startup>

--- a/test/Sitecore.FakeDb.Tests/App.config
+++ b/test/Sitecore.FakeDb.Tests/App.config
@@ -57,7 +57,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.0.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-4.11.0.0" newVersion="4.11.0.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/test/Sitecore.FakeDb.Tests/ContentSearch/SwitchingSearchProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/ContentSearch/SwitchingSearchProviderTest.cs
@@ -1,6 +1,5 @@
-﻿namespace Sitecore.FakeDb.Tests.ContentSearch
+namespace Sitecore.FakeDb.Tests.ContentSearch
 {
-    using System;
     using FluentAssertions;
     using NSubstitute;
     using global::AutoFixture.Xunit2;
@@ -19,7 +18,6 @@
             sut.GetContextIndexName(null).Should().BeNull();
         }
 
-        [Obsolete]
         [Theory, AutoData]
         public void ShouldReturnNullByIIndexableAndIPipelineIfCurrentProviderIsNull(
             SwitchingSearchProvider sut)
@@ -41,12 +39,11 @@
             }
         }
 
-        [Obsolete]
         [Theory, DefaultSubstituteAutoData]
         public void ShouldReturnCurrentNameByIIndexableAndIPipeline(
             [Frozen] SearchProvider current,
             IIndexable indexable,
-            ICorePipeline pipeline,
+            BaseCorePipelineManager pipeline,
             string expected,
             SwitchingSearchProvider sut)
         {

--- a/test/Sitecore.FakeDb.Tests/Data/DataProviders/FakeDataProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/DataProviders/FakeDataProviderTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Tests.Data.DataProviders
+namespace Sitecore.FakeDb.Tests.Data.DataProviders
 {
     using System;
     using System.IO;
@@ -265,6 +265,7 @@
             sut.DataStorage.Received().RemoveFakeItem(item.ID);
         }
 
+        [Obsolete]
         [Theory, DefaultAutoData]
         public void GetBlobStreamReturnsBlobStreamFromDataStorage(
             [Greedy] FakeDataProvider sut,
@@ -276,6 +277,7 @@
             sut.GetBlobStream(blobId, context).Should().BeSameAs(stream);
         }
 
+        [Obsolete]
         [Theory, DefaultAutoData]
         public void GetBlobStreamReturnsNullIfNoBlobStreamExists(
             [Greedy] FakeDataProvider sut,
@@ -505,53 +507,6 @@
             sut.GetItemVersions(def, context).Should().BeEmpty();
         }
 
-        [Obsolete]
-        [Theory, DefaultAutoData]
-        public void ShouldSetPropertyAndReturnTrue(FakeDataProvider sut, string name, string value, CallContext context)
-        {
-            sut.SetProperty(name, value, context).Should().BeTrue();
-        }
-
-        [Obsolete]
-        [Theory, DefaultAutoData]
-        public void ShouldThrowIfNameIsNullOnSetProperty(FakeDataProvider sut)
-        {
-            Action action = () => sut.SetProperty(null, null, null);
-            action.ShouldThrow<ArgumentNullException>().WithMessage("*name");
-        }
-
-        [Obsolete]
-        [Theory, DefaultAutoData]
-        public void ShouldGetProperty(FakeDataProvider sut, string name, string value, CallContext context)
-        {
-            sut.SetProperty(name, value, context);
-            sut.GetProperty(name, context).Should().Be(value);
-        }
-
-        [Obsolete]
-        [Theory, DefaultAutoData]
-        public void ShouldThrowIfNameIsNullOnGetProperty(FakeDataProvider sut)
-        {
-            Action action = () => sut.GetProperty(null, null);
-            action.ShouldThrow<ArgumentNullException>().WithMessage("*name");
-        }
-
-        [Obsolete]
-        [Theory, DefaultAutoData]
-        public void ShouldReturnNullIfNoPropertySet(FakeDataProvider sut, string name, CallContext context)
-        {
-            sut.GetProperty(name, context).Should().BeNull();
-        }
-
-        [Obsolete]
-        [Theory, DefaultAutoData]
-        public void ShouldResetPropertyAndReturnTheLatestValue(FakeDataProvider sut, string name, string value1, string value2, CallContext context)
-        {
-            sut.SetProperty(name, value1, context);
-            sut.SetProperty(name, value2, context);
-            sut.GetProperty(name, context).Should().Be(value2);
-        }
-
         [Theory, DefaultAutoData]
         public void ShouldGetNullItemFieldsIfNoItemFound([Greedy] FakeDataProvider sut, ItemDefinition def, VersionUri versionUri, CallContext context)
         {
@@ -748,6 +703,7 @@
             item.ParentID.Should().Be(newDestination.ID);
         }
 
+        [Obsolete]
         [Theory, DefaultAutoData]
         public void ShouldSetBlobStreamInDataStorage(
             [Greedy] FakeDataProvider sut,

--- a/test/Sitecore.FakeDb.Tests/Data/DataProviders/FakeDataProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/DataProviders/FakeDataProviderTest.cs
@@ -101,7 +101,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             action.ShouldThrow<ArgumentNullException>().Which.ParamName.Should().Be("copyId");
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void CopyItemThrowsIfNoDestinationItemFound(
             [Greedy] FakeDataProvider sut,
             ItemDefinition source,
@@ -116,7 +116,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
                     .FormatWith(copyName, source.ID));
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void CopyItemReturnsTrue(
             [Greedy] FakeDataProvider sut,
             ItemDefinition source,
@@ -131,7 +131,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
                 .Should().BeTrue();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void CopyItemAddsCopiedItemToDataStorage(
             [Greedy] FakeDataProvider sut,
             ItemDefinition source,
@@ -178,7 +178,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             action.ShouldThrow<ArgumentNullException>().WithMessage("*parent");
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void CreateItemAddsFakeItemToDataStorage(
             [Greedy] FakeDataProvider sut,
             ID itemId,
@@ -195,7 +195,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
                                     i.ParentID == parent.ID));
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void CreateItemAddsReturnsTrue(
             [Greedy] FakeDataProvider sut,
             ID itemId,
@@ -266,7 +266,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         }
 
         [Obsolete]
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetBlobStreamReturnsBlobStreamFromDataStorage(
             [Greedy] FakeDataProvider sut,
             Guid blobId,
@@ -278,7 +278,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         }
 
         [Obsolete]
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetBlobStreamReturnsNullIfNoBlobStreamExists(
             [Greedy] FakeDataProvider sut,
             Guid blobId,
@@ -287,7 +287,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             sut.GetBlobStream(blobId, context).Should().BeNull();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetChildIdsThrowsIfItemDefinitionIsNull(
             [Greedy] FakeDataProvider sut,
             CallContext context)
@@ -296,7 +296,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             action.ShouldThrow<ArgumentNullException>().WithMessage("*itemDefinition");
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetChildIdsReturnsEmptyListIfNoItemFound(
             [Greedy] FakeDataProvider sut,
             ItemDefinition itemDefinition,
@@ -305,7 +305,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             sut.GetChildIDs(itemDefinition, context).Should().BeEmpty();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetChildIdsReturnsChildIds(
             [Greedy] FakeDataProvider sut,
             ItemDefinition itemDefinition,
@@ -322,15 +322,17 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             sut.GetChildIDs(itemDefinition, context).ShouldBeEquivalentTo(expected);
         }
 
-        [Theory, DefaultAutoData]
-        public void GetParendIdThrowsIfItemDefinitionIsNull([Greedy] FakeDataProvider sut, CallContext context)
+        [Theory, DefaultSubstituteAutoData]
+        public void GetParentIdThrowsIfItemDefinitionIsNull(
+            [Greedy] FakeDataProvider sut,
+            CallContext context)
         {
             Action action = () => sut.GetParentID(null, context);
             action.ShouldThrow<ArgumentNullException>().WithMessage("*itemDefinition");
         }
 
-        [Theory, DefaultAutoData]
-        public void GetParendIdReturnsParentId(
+        [Theory, DefaultSubstituteAutoData]
+        public void GetParentIdReturnsParentId(
             [Greedy] FakeDataProvider sut,
             ItemDefinition itemDefinition,
             DbItem item,
@@ -341,8 +343,8 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             result.Should().Be(item.ParentID);
         }
 
-        [Theory, DefaultAutoData]
-        public void GetParendIdReturnsNullIfNoItemFound(
+        [Theory, DefaultSubstituteAutoData]
+        public void GetParentIdReturnsNullIfNoItemFound(
             [Greedy] FakeDataProvider sut,
             ItemDefinition itemDefinition,
             CallContext context)
@@ -351,8 +353,8 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             result.Should().BeNull();
         }
 
-        [Theory, DefaultAutoData]
-        public void GetParendIdReturnsNullForSitecoreRootItem(
+        [Theory, DefaultSubstituteAutoData]
+        public void GetParentIdReturnsNullForSitecoreRootItem(
             [Greedy] FakeDataProvider sut,
             string itemName,
             ID id,
@@ -382,9 +384,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         public void ShouldGetTemplatesWithDefaultDataSectionFromDataStorage([Greedy] FakeDataProvider sut, DbTemplate template)
         {
             sut.DataStorage.GetFakeTemplates().Returns(new[] { template });
-
             var result = sut.GetTemplates(null).First();
-
             result.GetSection("Data").Should().NotBeNull();
         }
 
@@ -392,9 +392,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         public void ShouldHaveStandardBaseTemplate([Greedy] FakeDataProvider sut, [NoAutoProperties] DbTemplate template)
         {
             sut.DataStorage.GetFakeTemplates().Returns(new[] { template });
-
             var result = sut.GetTemplates(null).First();
-
             result.BaseIDs.Single().Should().Be(TemplateIDs.StandardTemplate);
         }
 
@@ -403,9 +401,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         {
             sut.DataStorage.GetFakeTemplates().Returns(new[] { template });
             template.Fields.Add("Title");
-
             var result = sut.GetTemplates(null).First();
-
             result.GetField("Title").Should().NotBeNull();
         }
 
@@ -414,9 +410,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         {
             sut.DataStorage.GetFakeTemplates().Returns(new[] { template });
             template.Fields.Add(new DbField("Link") { Type = "General Link" });
-
             var result = sut.GetTemplates(null).First();
-
             result.GetField("Link").Type.Should().Be("General Link");
         }
 
@@ -425,9 +419,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         {
             sut.DataStorage.GetFakeTemplates().Returns(new[] { template });
             template.Fields.Add(new DbField("Title") { Shared = true });
-
             var result = sut.GetTemplates(null).First();
-
             result.GetField("Title").IsShared.Should().BeTrue();
         }
 
@@ -436,21 +428,24 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         {
             sut.DataStorage.GetFakeTemplates().Returns(new[] { template });
             template.Fields.Add(new DbField("Multilist") { Source = "/sitecore/content" });
-
             var result = sut.GetTemplates(null).First();
-
             result.GetField("Multilist").Source.Should().Be("/sitecore/content");
         }
 
-        [Theory, DefaultAutoData]
-        public void ShouldGetDefaultLanguage([Greedy] FakeDataProvider sut, CallContext context)
+        [Theory, DefaultSubstituteAutoData]
+        public void ShouldGetDefaultLanguage(
+            [Greedy] FakeDataProvider sut,
+            CallContext context)
         {
-            var langs = sut.GetLanguages(context);
-            langs.Should().BeEmpty();
+            var languages = sut.GetLanguages(context);
+            languages.Should().BeEmpty();
         }
 
-        [Theory, DefaultAutoData]
-        public void ShouldGetItemDefinition([Greedy] FakeDataProvider sut, DbItem item, CallContext context)
+        [Theory, DefaultSubstituteAutoData]
+        public void ShouldGetItemDefinition(
+            [Greedy] FakeDataProvider sut,
+            DbItem item,
+            CallContext context)
         {
             // arrange
             sut.DataStorage.GetFakeItem(item.ID).Returns(item);
@@ -465,14 +460,20 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             definition.BranchId.Should().Be(ID.Null);
         }
 
-        [Theory, DefaultAutoData]
-        public void ShouldGetNullItemDefinitionIfNoItemFound([Greedy] FakeDataProvider sut, ID itemId, CallContext context)
+        [Theory, DefaultSubstituteAutoData]
+        public void ShouldGetNullItemDefinitionIfNoItemFound(
+            [Greedy] FakeDataProvider sut,
+            ID itemId,
+            CallContext context)
         {
             sut.GetItemDefinition(itemId, context).Should().BeNull();
         }
 
-        [Theory, DefaultAutoData]
-        public void ShouldGetAllThePossibleItemVersions([Greedy] FakeDataProvider sut, ItemDefinition def, CallContext context)
+        [Theory, DefaultSubstituteAutoData]
+        public void ShouldGetAllThePossibleItemVersions(
+            [Greedy] FakeDataProvider sut,
+            ItemDefinition def,
+            CallContext context)
         {
             // arrange
             var item = new DbItem("home", def.ID, def.TemplateID)
@@ -483,7 +484,6 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
                             new DbField("Field 2") {{"en", 1, string.Empty}, {"da", 1, string.Empty}, {"da", 2, string.Empty}}
                         }
             };
-
             sut.DataStorage.GetFakeItem(def.ID).Returns(item);
 
             // act
@@ -501,20 +501,33 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             versions[3].Version.Number.Should().Be(2);
         }
 
-        [Theory, DefaultAutoData]
-        public void ShouldGetEmptyVersionsIfNoFakeItemFound([Greedy] FakeDataProvider sut, ItemDefinition def, CallContext context)
+        [Theory, DefaultSubstituteAutoData]
+        public void ShouldGetEmptyVersionsIfNoFakeItemFound(
+            [Greedy] FakeDataProvider sut,
+            ItemDefinition def,
+            CallContext context)
         {
             sut.GetItemVersions(def, context).Should().BeEmpty();
         }
 
-        [Theory, DefaultAutoData]
-        public void ShouldGetNullItemFieldsIfNoItemFound([Greedy] FakeDataProvider sut, ItemDefinition def, VersionUri versionUri, CallContext context)
+        [Theory, DefaultSubstituteAutoData]
+        public void ShouldGetNullItemFieldsIfNoItemFound(
+            [Greedy] FakeDataProvider sut,
+            ItemDefinition def,
+            VersionUri versionUri,
+            CallContext context)
         {
             sut.GetItemFields(def, versionUri, context).Should().BeNull();
         }
 
-        [Theory, DefaultAutoData]
-        public void ShouldGetItemFields([Greedy] FakeDataProvider sut, DbTemplate template, DbItem item, DbField field, Language language, Version version,
+        [Theory, DefaultSubstituteAutoData]
+        public void ShouldGetItemFields(
+            [Greedy] FakeDataProvider sut,
+            DbTemplate template,
+            DbItem item,
+            DbField field,
+            Language language,
+            Version version,
             CallContext context)
         {
             template.Fields.Add(field);
@@ -530,7 +543,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             sut.GetItemFields(def, versionUri, context).Should().HaveCount(1);
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void AddToPublishQueueReturnsTrue(
             [Greedy] FakeDataProvider sut,
             ID itemId,
@@ -541,7 +554,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             sut.AddToPublishQueue(itemId, action, date, context).Should().BeTrue();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void AddToPublishQueueWithLanguageReturnsTrue(
             [Greedy] FakeDataProvider sut,
             ID itemId,
@@ -553,7 +566,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             sut.AddToPublishQueue(itemId, action, date, language, context).Should().BeTrue();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void AddToPublishQueueSameItemIdMultipleTimesReturnsTrue(
             [Greedy] FakeDataProvider sut,
             ID itemId,
@@ -566,7 +579,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             sut.AddToPublishQueue(itemId, action, date, context).Should().BeTrue();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetPublishQueueReturnsIdList(
             [Greedy] FakeDataProvider sut,
             ID itemId1,
@@ -581,7 +594,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             result.ShouldBeEquivalentTo(new IDList { itemId1, itemId2 });
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetPublishQueueReturnsEmptyIdListIfNoItemsAdded(
             [Greedy] FakeDataProvider sut,
             CallContext context)
@@ -591,11 +604,11 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         }
 
         [Theory]
-        [InlineDefaultAutoData(-1, 0, 1)]
-        [InlineDefaultAutoData(0, 0, 1)]
-        [InlineDefaultAutoData(0, 1, 1)]
-        [InlineDefaultAutoData(1, 2, 0)]
-        [InlineDefaultAutoData(-2, -1, 0)]
+        [InlineDefaultSubstituteAutoData(-1, 0, 1)]
+        [InlineDefaultSubstituteAutoData(0, 0, 1)]
+        [InlineDefaultSubstituteAutoData(0, 1, 1)]
+        [InlineDefaultSubstituteAutoData(1, 2, 0)]
+        [InlineDefaultSubstituteAutoData(-2, -1, 0)]
         public void GetPublishQueueReturnsIdListFilteredByDates(
             int daysBeforePublishingDate,
             int daysAfterPublishingDate,
@@ -615,7 +628,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             result.Count.Should().Be(expectedCount);
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetPublishQueueReturnsIdListWithoutDuplicatedIDs(
             [Greedy] FakeDataProvider sut,
             ID itemId,
@@ -704,7 +717,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         }
 
         [Obsolete]
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void ShouldSetBlobStreamInDataStorage(
             [Greedy] FakeDataProvider sut,
             Guid blobId,
@@ -716,30 +729,29 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
         }
 
         [Theory]
-        [InlineDefaultAutoData("/sitecore/content/home")]
-        [InlineDefaultAutoData("/Sitecore/Content/Home")]
-        [InlineDefaultAutoData("/Sitecore/Content/Home/")]
+        [InlineDefaultSubstituteAutoData("/sitecore/content/home")]
+        [InlineDefaultSubstituteAutoData("/Sitecore/Content/Home")]
+        [InlineDefaultSubstituteAutoData("/Sitecore/Content/Home/")]
         public void ShouldResolvePath(string path, [Greedy] FakeDataProvider sut, DbItem item, CallContext context)
         {
             item.FullPath = "/sitecore/content/home";
             sut.DataStorage.GetFakeItems().Returns(new[] { item });
-
             sut.ResolvePath(path, context).Should().Be(item.ID);
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void ShouldReturnNullIfNoItemFound([Greedy] FakeDataProvider sut, string path, CallContext context)
         {
             sut.ResolvePath(path, context).Should().BeNull();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void ShouldReturnIdIfPathIsId([Greedy] FakeDataProvider sut, ID itemId, CallContext context)
         {
             sut.ResolvePath(itemId.ToString(), context).Should().Be(itemId);
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void ShouldResolveFirstItemId(
             [Greedy] FakeDataProvider sut,
             DbItem item1,
@@ -750,7 +762,6 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             item1.FullPath = path;
             item2.FullPath = path;
             sut.DataStorage.GetFakeItems().Returns(new[] { item1, item2 });
-
             sut.ResolvePath(path, context).Should().Be(item1.ID);
         }
 
@@ -801,7 +812,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             item.AddVersion(language.Name);
             item.AddVersion(language.Name);
             var version = new VersionUri(language, Version.Latest);
-            var expectedVersionCount = 1;
+            const int expectedVersionCount = 1;
 
             var result = sut.RemoveVersion(itemDefinition, version, null);
 
@@ -825,7 +836,7 @@ namespace Sitecore.FakeDb.Tests.Data.DataProviders
             action.ShouldThrow<ArgumentNullException>().Which.ParamName.Should().Be("changes");
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void SaveItemReturnsFalse(
             [Greedy] FakeDataProvider sut,
             ItemDefinition itemDefinition,

--- a/test/Sitecore.FakeDb.Tests/Data/DataProviders/SwitchingLanguageDataProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/DataProviders/SwitchingLanguageDataProviderTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Tests.Data.DataProviders
+namespace Sitecore.FakeDb.Tests.Data.DataProviders
 {
     using FluentAssertions;
     using global::AutoFixture.Xunit2;
@@ -17,7 +17,7 @@
             sut.Should().BeAssignableTo<DataProvider>();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetLanguagesReturnsEmptyCollectionIfNoLanguagesSwitched(
             SwitchingLanguageDataProvider sut,
             CallContext context)
@@ -26,7 +26,7 @@
                 .Should().BeEmpty();
         }
 
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void GetLanguagesReturnsLanguagesIfSwitched(
             SwitchingLanguageDataProvider sut,
             CallContext context)
@@ -37,7 +37,7 @@
             using (new Switcher<DbLanguages>(contextLanguages))
             {
                 sut.GetLanguages(context)
-                    .ShouldAllBeEquivalentTo(new[] {en, da});
+                    .ShouldAllBeEquivalentTo(new[] { en, da });
             }
         }
     }

--- a/test/Sitecore.FakeDb.Tests/Data/FakeStandardValuesProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/FakeStandardValuesProviderTest.cs
@@ -1,9 +1,10 @@
-﻿namespace Sitecore.FakeDb.Tests.Data
+namespace Sitecore.FakeDb.Tests.Data
 {
     using System;
     using FluentAssertions;
     using NSubstitute;
     using global::AutoFixture.Xunit2;
+    using Sitecore.Abstractions;
     using Sitecore.Data;
     using Sitecore.Data.Fields;
     using Sitecore.FakeDb.Data;
@@ -13,7 +14,7 @@
 
     public class FakeStandardValuesProviderTest
     {
-        [Theory, DefaultAutoData]
+        [Theory, DefaultSubstituteAutoData]
         public void ShouldReturnEmptyStringIfNoTemplateFound(
             FakeStandardValuesProvider sut,
             [Greedy] Field field,
@@ -25,13 +26,15 @@
             }
         }
 
-        [Fact]
-        public void ShouldThrowIfNoDataStorageSet()
+        [Theory, DefaultSubstituteAutoData]
+        public void ShouldThrowIfNoDataStorageSet(
+            BaseItemManager itemManager,
+            BaseTemplateManager templateManager,
+            BaseFactory factory)
         {
             // arrange
-            var sut = Substitute.ForPartsOf<FakeStandardValuesProvider>();
+            var sut = Substitute.ForPartsOf<FakeStandardValuesProvider>(itemManager, templateManager, factory);
             sut.DataStorage(Arg.Any<Database>()).Returns((DataStorage)null);
-
             var field = new Field(ID.NewID, ItemHelper.CreateInstance());
 
             // act

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/BlobFieldTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/BlobFieldTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Tests.Data.Fields
+namespace Sitecore.FakeDb.Tests.Data.Fields
 {
     using System.IO;
     using FluentAssertions;
@@ -8,13 +8,13 @@
     [Trait("Category", "RequireLicense")]
     public class BlobFieldTest
     {
-        [Fact]
+        [Fact(Skip = "Temporary disabled. TBI in #214.")]
         public void ShouldSetAndGetBlobStream()
         {
             // arrange
             var stream = new MemoryStream();
 
-            using (var db = new Db {new DbItem("home") {new DbField("field")}})
+            using (var db = new Db { new DbItem("home") { new DbField("field") } })
             {
                 var item = db.GetItem("/sitecore/content/home");
                 var field = item.Fields["field"];
@@ -27,7 +27,7 @@
                 }
 
                 // assert
-                var actual = (MemoryStream) field.GetBlobStream();
+                var actual = (MemoryStream)field.GetBlobStream();
                 actual.ToArray().Should().BeEquivalentTo(stream.ToArray());
             }
         }

--- a/test/Sitecore.FakeDb.Tests/Data/Fields/FieldTypeManagerTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Data/Fields/FieldTypeManagerTest.cs
@@ -18,9 +18,6 @@ namespace Sitecore.FakeDb.Tests.Data.Fields
         [InlineData("Image", typeof(ImageField))]
         [InlineData("Rich Text", typeof(HtmlField))]
         [InlineData("Single-Line Text", typeof(TextField))]
-#pragma warning disable 618
-        [InlineData("Word Document", typeof(WordDocumentField))]
-#pragma warning restore 618
         [InlineData("Multi-Line Text", typeof(TextField))]
 
         // List Types

--- a/test/Sitecore.FakeDb.Tests/DbConcurrencyTest.cs
+++ b/test/Sitecore.FakeDb.Tests/DbConcurrencyTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Tests
+namespace Sitecore.FakeDb.Tests
 {
     using System;
     using System.Threading;
@@ -148,33 +148,6 @@
                 {
                     db.Configuration.Settings["mysetting"] = "abc";
                     Settings.GetSetting("mysetting").Should().Be("abc");
-                }
-            });
-
-            t1.Wait();
-            t2.Wait();
-        }
-
-        [Obsolete]
-        [Theory(Skip = "Not supported in Sitecore 9"), AutoData]
-        public void ShouldBeThreadLocalDatabaseProperties(string propertyName, string expectedValue, string unexpectedValue)
-        {
-            var t1 = Task.Factory.StartNew(() =>
-            {
-                using (var db = new Db())
-                {
-                    db.Database.Properties[propertyName] = expectedValue;
-                    Thread.Sleep(1000);
-                    db.Database.Properties[propertyName].Should().Be(expectedValue);
-                }
-            });
-
-            var t2 = Task.Factory.StartNew(() =>
-            {
-                using (var db = new Db())
-                {
-                    db.Database.Properties[propertyName].Should().BeEmpty("the property is not expected");
-                    db.Database.Properties[propertyName] = unexpectedValue;
                 }
             });
 

--- a/test/Sitecore.FakeDb.Tests/DefaultAutoDataAttribute.cs
+++ b/test/Sitecore.FakeDb.Tests/DefaultAutoDataAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Tests
+namespace Sitecore.FakeDb.Tests
 {
     using System;
     using NSubstitute;
@@ -37,6 +37,14 @@
             : base(() => new Fixture()
                 .Customize(new DefaultConventions())
                 .Customize(new AutoNSubstituteCustomization()))
+        {
+        }
+    }
+
+    internal class InlineDefaultSubstituteAutoDataAttribute : InlineAutoDataAttribute
+    {
+        public InlineDefaultSubstituteAutoDataAttribute(params object[] values)
+            : base(new DefaultSubstituteAutoDataAttribute(), values)
         {
         }
     }

--- a/test/Sitecore.FakeDb.Tests/GettingStarted.cs
+++ b/test/Sitecore.FakeDb.Tests/GettingStarted.cs
@@ -1,4 +1,4 @@
-﻿namespace Examples
+namespace Examples
 {
     using System;
     using System.Linq;
@@ -238,7 +238,7 @@
             }
         }
 
-    [Obsolete]
+        [Obsolete]
         [Fact]
         public void HowToMockRoleProvider()
         {
@@ -258,7 +258,7 @@
             }
         }
 
-    [Obsolete]
+        [Obsolete]
         [Fact]
         public void HowToMockMembershipProvider()
         {
@@ -278,7 +278,7 @@
             }
         }
 
-    [Obsolete]
+        [Obsolete]
         [Fact]
         public void HowToUnitTestItemSecurityWithFakeProvider()
         {
@@ -608,7 +608,7 @@
             }
         }
 
-    [Obsolete]
+        [Obsolete]
         [Fact]
         public void HowToWorkWithQueryApi()
         {
@@ -711,7 +711,7 @@
 
         #region Blobs
 
-        [Fact]
+        [Fact(Skip = "Temporary disabled. TBI in #214.")]
         public void HowToSetAndGetBlobStream()
         {
             // arrange

--- a/test/Sitecore.FakeDb.Tests/Links/LinkManagerTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Links/LinkManagerTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Tests.Links
+namespace Sitecore.FakeDb.Tests.Links
 {
     using FluentAssertions;
     using Sitecore.Links;
@@ -16,7 +16,7 @@
                 var item = db.GetItem("/sitecore/content/home");
 
                 // act & assert
-                LinkManager.GetItemUrl(item).Should().Be("/en/sitecore/content/home.aspx");
+                LinkManager.GetItemUrl(item).Should().Be("/en/sitecore/content/home");
             }
         }
     }

--- a/test/Sitecore.FakeDb.Tests/Links/SwitchingLinkProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Links/SwitchingLinkProviderTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Tests.Links
+namespace Sitecore.FakeDb.Tests.Links
 {
     using System;
     using System.Collections.Specialized;
@@ -176,7 +176,10 @@
         }
 
         [Theory, SwitchingAutoData]
-        public void ParseRequestUrlCallsCurrentProvider(SwitchingLinkProvider sut, [Substitute] LinkProvider current, HttpRequest request)
+        public void ParseRequestUrlCallsCurrentProvider(
+            SwitchingLinkProvider sut,
+            [Substitute] LinkProvider current,
+            HttpRequestBase request)
         {
             using (new Switcher<LinkProvider>(current))
             {
@@ -185,7 +188,9 @@
         }
 
         [Theory, SwitchingAutoData]
-        public void ParseRequestUrlCallsBaseProviderIfCurrentNotSet(SwitchingLinkProvider sut, HttpRequest request)
+        public void ParseRequestUrlCallsBaseProviderIfCurrentNotSet(
+            SwitchingLinkProvider sut,
+            HttpRequestBase request)
         {
             sut.ParseRequestUrl(request).Should().NotBeNull();
         }

--- a/test/Sitecore.FakeDb.Tests/Resources/Media/FakeMediaProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Resources/Media/FakeMediaProviderTest.cs
@@ -1,4 +1,6 @@
-﻿namespace Sitecore.FakeDb.Tests.Resources.Media
+using Sitecore.Links.UrlBuilders;
+
+namespace Sitecore.FakeDb.Tests.Resources.Media
 {
     using System;
     using FluentAssertions;
@@ -37,10 +39,10 @@
             mediaProvider.MediaLinkPrefix.Should().NotBeNull();
             mediaProvider.MimeResolver.Should().NotBeNull();
 
-            mediaProvider.GetMedia((MediaItem) null).Should().BeNull();
-            mediaProvider.GetMedia((MediaUri) null).Should().BeNull();
+            mediaProvider.GetMedia((MediaItem)null).Should().BeNull();
+            mediaProvider.GetMedia((MediaUri)null).Should().BeNull();
             mediaProvider.GetMediaUrl(null).Should().BeNull();
-            mediaProvider.GetMediaUrl(null, null).Should().BeNull();
+            mediaProvider.GetMediaUrl(null, (MediaUrlBuilderOptions)null).Should().BeNull();
             mediaProvider.GetThumbnailUrl(null).Should().BeNull();
             mediaProvider.HasMediaContent(null).Should().BeFalse();
             mediaProvider.IsMediaRequest(null).Should().BeFalse();
@@ -185,10 +187,10 @@
             var mock = CreateMediaItemMock();
 
             // act
-            this.localProvider.GetMediaUrl(mock, null).Returns("http://smth");
+            this.localProvider.GetMediaUrl(mock, (MediaUrlBuilderOptions)null).Returns("http://smth");
 
             // assert
-            this.provider.GetMediaUrl(mock, null).Should().Be("http://smth");
+            this.provider.GetMediaUrl(mock, (MediaUrlBuilderOptions)null).Should().Be("http://smth");
         }
 
         [Fact]

--- a/test/Sitecore.FakeDb.Tests/Samples/ContentSearchSamples.cs
+++ b/test/Sitecore.FakeDb.Tests/Samples/ContentSearchSamples.cs
@@ -1,4 +1,4 @@
-﻿namespace Sitecore.FakeDb.Tests.Samples
+namespace Sitecore.FakeDb.Tests.Samples
 {
     using System;
     using System.Collections.Generic;
@@ -15,7 +15,6 @@
     /// </summary>
     public class ContentSearchSamples
     {
-        [Obsolete]
         [Fact]
         public void ShouldGetProducts()
         {
@@ -37,7 +36,7 @@
 
             var indexable = Substitute.For<IIndexable>();
             var provider = Substitute.For<SearchProvider>();
-            provider.GetContextIndexName(indexable, Arg.Any<ICorePipeline>()).Returns("fake_index");
+            provider.GetContextIndexName(indexable, Arg.Any<BaseCorePipelineManager>()).Returns("fake_index");
 
             using (new Switcher<SearchProvider>(provider))
             {

--- a/test/Sitecore.FakeDb.Tests/Security/AccessControl/FakeAuthorizationProviderTest.cs
+++ b/test/Sitecore.FakeDb.Tests/Security/AccessControl/FakeAuthorizationProviderTest.cs
@@ -1,10 +1,10 @@
-﻿namespace Sitecore.FakeDb.Tests.Security.AccessControl
+namespace Sitecore.FakeDb.Tests.Security.AccessControl
 {
     using System;
     using FluentAssertions;
     using NSubstitute;
     using global::AutoFixture;
-    using Sitecore.Configuration;
+    using Sitecore.Abstractions;
     using Sitecore.Data.Items;
     using Sitecore.FakeDb.Data.Items;
     using Sitecore.FakeDb.Security.AccessControl;
@@ -28,10 +28,12 @@
 
         public FakeAuthorizationProviderTest()
         {
-            this.provider = new FakeAuthorizationProvider();
-
             this.localProvider = Substitute.For<AuthorizationProvider>();
-            this.helper = Substitute.For<ItemAuthorizationHelper>();
+            this.helper = Substitute.For<ItemAuthorizationHelper>(
+                Substitute.For<BaseAccessRightManager>(),
+                Substitute.For<BaseRolesInRolesManager>(),
+                Substitute.For<BaseItemManager>());
+            this.provider = new FakeAuthorizationProvider(helper);
 
             this.entity = Substitute.For<ISecurable>();
             this.item = ItemHelper.CreateInstance();

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -61,11 +61,11 @@
       <HintPath>..\..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.1.1\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.2.2.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -67,6 +67,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -89,8 +89,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=4.2.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NSubstitute.4.2.1\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Buckets">
       <HintPath>..\..\lib\Sitecore.Buckets.dll</HintPath>

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -67,6 +67,12 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -73,6 +73,9 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Options.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EnterpriseLibrary.Common.6.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\version.props" />
   <PropertyGroup>
@@ -140,17 +140,17 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.2\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.4.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.4.0\lib\net452\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.4.0.4049, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.0\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -335,11 +335,12 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.0\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
   </Target>
   <Import Project="..\..\packages\xunit.core.2.4.0\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.0\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -38,14 +38,14 @@
     <CodeAnalysisRuleSet>..\..\Sitecore.FakeDb.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    <Reference Include="AutoFixture, Version=4.11.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.4.11.0\lib\net452\AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.AutoNSubstitute.4.0.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
+    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.11.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.AutoNSubstitute.4.11.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="AutoFixture.Xunit2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoFixture.Xunit2.4.0.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    <Reference Include="AutoFixture.Xunit2, Version=4.11.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.Xunit2.4.11.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -104,6 +104,12 @@
     <Reference Include="Sitecore.ContentSearch.Linq">
       <HintPath>..\..\lib\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="Sitecore.Framework.Data.Blobs, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sitecore.Framework.Data.Blobs.1.0.0\lib\netstandard2.0\Sitecore.Framework.Data.Blobs.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Framework.Data.Blobs.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sitecore.Framework.Data.Blobs.Abstractions.1.0.0\lib\netstandard2.0\Sitecore.Framework.Data.Blobs.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\lib\Sitecore.Kernel.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
+++ b/test/Sitecore.FakeDb.Tests/Sitecore.FakeDb.Tests.csproj
@@ -77,9 +77,6 @@
     <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NSubstitute.3.1.0\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.Abstractions">
-      <HintPath>..\..\lib\Sitecore.Abstractions.dll</HintPath>
-    </Reference>
     <Reference Include="Sitecore.Buckets">
       <HintPath>..\..\lib\Sitecore.Buckets.dll</HintPath>
     </Reference>

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -7,8 +7,8 @@
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="Fare" version="2.1.1" targetFramework="net452" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -22,12 +22,12 @@
   <package id="Sitecore.Nexus.Licensing" version="2.0.6" targetFramework="net471" />
   <package id="System.Security.Cryptography.Xml" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />
-  <package id="xunit" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.2" targetFramework="net452" />
-  <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.4.0" targetFramework="net452" requireReinstallation="true" />
-  <package id="xunit.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.4.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.4.0" targetFramework="net452" developmentDependency="true" />
+  <package id="xunit" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net471" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net471" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net471" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net471" developmentDependency="true" />
 </packages>

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -9,6 +9,8 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
-  <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
+  <package id="NSubstitute" version="4.2.1" targetFramework="net471" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.Framework.Data.Blobs" version="1.0.0" targetFramework="net471" />
   <package id="Sitecore.Framework.Data.Blobs.Abstractions" version="1.0.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="4.0.0" targetFramework="net452" />
-  <package id="AutoFixture.AutoNSubstitute" version="4.0.0" targetFramework="net452" />
-  <package id="AutoFixture.Xunit2" version="4.0.0" targetFramework="net452" />
+  <package id="AutoFixture" version="4.11.0" targetFramework="net471" />
+  <package id="AutoFixture.AutoNSubstitute" version="4.11.0" targetFramework="net471" />
+  <package id="AutoFixture.Xunit2" version="4.11.0" targetFramework="net471" />
   <package id="Castle.Core" version="4.2.0" targetFramework="net452" />
   <package id="EnterpriseLibrary.Common" version="6.0.1304.0" targetFramework="net471" />
   <package id="Fare" version="2.1.1" targetFramework="net452" />

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -9,6 +9,8 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net471" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -17,6 +17,8 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />
+  <package id="Sitecore.Framework.Data.Blobs" version="1.0.0" targetFramework="net471" />
+  <package id="Sitecore.Framework.Data.Blobs.Abstractions" version="1.0.0" targetFramework="net471" />
   <package id="Sitecore.Nexus.Licensing" version="2.0.6" targetFramework="net471" />
   <package id="System.Security.Cryptography.Xml" version="4.6.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net452" />

--- a/test/Sitecore.FakeDb.Tests/packages.config
+++ b/test/Sitecore.FakeDb.Tests/packages.config
@@ -11,6 +11,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net452" requireReinstallation="true" />
   <package id="Sitecore.ContentSearch.ContentExtraction" version="9.2.0" targetFramework="net471" />

--- a/version.props
+++ b/version.props
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This setting allows to specify list of Sitecore versions to build and 
          run tests against before publishing the NuGet packages.
     -->
-    <SupportedSitecoreVersions>9.1.0;9.1.1;9.2.0</SupportedSitecoreVersions>
+    <SupportedSitecoreVersions>9.3.0</SupportedSitecoreVersions>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Upgrade to Sitecore 9.3.

Almost all the existing functionality works fine. There are few (minor) limitations so far:
- no blobs
- no database properties

I guess it's fine to publish an update without these two.

I haven't upgraded the codebase to SDK projects and NuSet PackageReference's as @sc-alistairdeneys suggested in #209. The suggestion still looks correct to me, but that requires more time. Any contribution is appreciated ;)
